### PR TITLE
Add implementation of worker pool, pulled from DatTCP

### DIFF
--- a/dat-worker-pool.gemspec
+++ b/dat-worker-pool.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.add_dependency("SystemTimer", ["~> 1.2"])
+
   gem.add_development_dependency("assert")
 
 end

--- a/lib/dat-worker-pool.rb
+++ b/lib/dat-worker-pool.rb
@@ -1,5 +1,142 @@
-require "dat-worker-pool/version"
+require 'logger'
+require 'system_timer'
+require 'thread'
 
-module DatWorkerPool
-  # TODO: your code goes here...
+require 'dat-worker-pool/version'
+require 'dat-worker-pool/queue'
+require 'dat-worker-pool/worker'
+
+class DatWorkerPool
+
+  TimeoutError = Class.new(RuntimeError)
+
+  attr_reader :logger, :spawned
+
+  def initialize(min = 0, max = 1, debug = false, &do_work_proc)
+    @min_workers  = min
+    @max_workers  = max
+    @debug        = debug
+    @logger       = Logger.new(@debug)
+    @do_work_proc = do_work_proc
+
+    @queue           = Queue.new
+    @workers_waiting = WorkersWaiting.new
+
+    @mutex   = Mutex.new
+    @workers = []
+    @spawned = 0
+
+    @min_workers.times{ self.spawn_worker }
+  end
+
+  def work_items
+    @queue.work_items
+  end
+
+  def waiting
+    @workers_waiting.count
+  end
+
+  # Check if all workers are busy before adding the work. When the work is
+  # added, a worker will stop waiting (if it was idle). Because of that, we
+  # can't reliably check if all workers are busy. We might think all workers are
+  # busy because we just woke up a sleeping worker to process this work. Then we
+  # would spawn a worker to do nothing.
+  def add_work(work_item)
+    return if work_item.nil?
+    new_worker_needed = all_workers_are_busy?
+    @queue.push work_item
+    self.spawn_worker if new_worker_needed && havent_reached_max_workers?
+  end
+
+  # Shutdown each worker and then the queue. Shutting down the queue will
+  # signal any workers waiting on it to wake up, so they can start shutting
+  # down. If a worker is processing work, then it will be joined and allowed to
+  # finish.
+  # **NOTE** Any work that is left on the queue isn't processed. The controlling
+  # application for the worker pool should gracefully handle these items.
+  def shutdown(timeout)
+    begin
+      SystemTimer.timeout(timeout, TimeoutError) do
+        @workers.each(&:shutdown)
+        @queue.shutdown
+
+        # use this pattern instead of `each` -- we don't want to call `join` on
+        # every worker (especially if they are shutting down on their own), we
+        # just want to make sure that any who haven't had a chance to finish
+        # get to (this is safe, otherwise you might get a dead thread in the
+        # `each`).
+        @workers.first.join until @workers.empty?
+      end
+    rescue TimeoutError => exception
+      exception.message.replace "Timed out shutting down the worker pool"
+      @debug ? raise(exception) : self.logger.error(exception.message)
+    end
+  end
+
+  # public, because workers need to call it for themselves
+  def despawn_worker(worker)
+    @mutex.synchronize do
+      @spawned -= 1
+      @workers.delete worker
+    end
+  end
+
+  protected
+
+  def spawn_worker
+    @mutex.synchronize do
+      worker = Worker.new(self, @queue, @workers_waiting) do |work_item|
+        do_work(work_item)
+      end
+      @workers << worker
+      @spawned += 1
+      worker
+    end
+  end
+
+  def do_work(work_item)
+    begin
+      @do_work_proc.call(work_item)
+    rescue Exception => exception
+      self.logger.error "Exception raised while doing work!"
+      self.logger.error "#{exception.class}: #{exception.message}"
+      self.logger.error exception.backtrace.join("\n")
+    end
+  end
+
+  def all_workers_are_busy?
+    @workers_waiting.count <= 0
+  end
+
+  def havent_reached_max_workers?
+    @mutex.synchronize do
+      @spawned < @max_workers
+    end
+  end
+
+  class WorkersWaiting
+    attr_reader :count
+
+    def initialize
+      @mutex = Mutex.new
+      @count = 0
+    end
+
+    def increment
+      @mutex.synchronize{ @count += 1 }
+    end
+
+    def decrement
+      @mutex.synchronize{ @count -= 1 }
+    end
+
+  end
+
+  module Logger
+    def self.new(debug)
+      debug ? ::Logger.new(STDOUT) : ::Logger.new(File.open('/dev/null', 'w'))
+    end
+  end
+
 end

--- a/lib/dat-worker-pool/queue.rb
+++ b/lib/dat-worker-pool/queue.rb
@@ -1,0 +1,50 @@
+require 'thread'
+
+class DatWorkerPool
+
+  class Queue
+
+    def initialize
+      @work_items = []
+      @shutdown = false
+      @mutex = Mutex.new
+      @condition_variable = ConditionVariable.new
+    end
+
+    def work_items
+      @mutex.synchronize{ @work_items }
+    end
+
+    # Add the work_item and wake up the first worker (the `signal`) that's
+    # waiting (because of `wait_for_work_item`)
+    def push(work_item)
+      raise "Unable to add work while shutting down" if @shutdown
+      @mutex.synchronize do
+        @work_items << work_item
+        @condition_variable.signal
+      end
+    end
+
+    def pop
+      @mutex.synchronize{ @work_items.shift }
+    end
+
+    def empty?
+      @mutex.synchronize{ @work_items.empty? }
+    end
+
+    # wait to be signaled by `push`
+    def wait_for_work_item
+      return if @shutdown
+      @mutex.synchronize{ @condition_variable.wait(@mutex) }
+    end
+
+    # wake up any workers who are idle (because of `wait_for_work_item`)
+    def shutdown
+      @shutdown = true
+      @mutex.synchronize{ @condition_variable.broadcast }
+    end
+
+  end
+
+end

--- a/lib/dat-worker-pool/version.rb
+++ b/lib/dat-worker-pool/version.rb
@@ -1,3 +1,3 @@
-module DatWorkerPool
+class DatWorkerPool
   VERSION = "0.0.1"
 end

--- a/lib/dat-worker-pool/worker.rb
+++ b/lib/dat-worker-pool/worker.rb
@@ -1,0 +1,48 @@
+require 'thread'
+
+class DatWorkerPool
+
+  class Worker
+
+    def initialize(pool, queue, workers_waiting, &block)
+      @pool            = pool
+      @queue           = queue
+      @workers_waiting = workers_waiting
+      @block           = block
+      @shutdown        = false
+      @thread          = Thread.new{ work_loop }
+    end
+
+    def shutdown
+      @shutdown = true
+    end
+
+    def join(*args)
+      @thread.join(*args) if @thread
+    end
+
+    protected
+
+    def work_loop
+      loop do
+        self.wait_for_work
+        break if @shutdown
+        @block.call @queue.pop
+      end
+    ensure
+      @pool.despawn_worker(self)
+    end
+
+    # Wait for work to process by checking if the queue is empty.
+    def wait_for_work
+      while @queue.empty?
+        return if @shutdown
+        @workers_waiting.increment
+        @queue.wait_for_work_item
+        @workers_waiting.decrement
+      end
+    end
+
+  end
+
+end

--- a/test/system/use_worker_pool_tests.rb
+++ b/test/system/use_worker_pool_tests.rb
@@ -1,0 +1,33 @@
+require 'assert'
+require 'dat-worker-pool'
+
+class UseWorkerPoolTests < Assert::Context
+
+  desc "defining a custom worker pool"
+  setup do
+    @mutex = Mutex.new
+    @results = []
+    @work_pool = DatWorkerPool.new(1, 2, !!ENV['DEBUG']) do |work|
+      @mutex.synchronize{ @results << (work * 100) }
+    end
+  end
+
+  should "be able to add work, have it processed and stop the pool" do
+    @work_pool.add_work 1
+    @work_pool.add_work 5
+    @work_pool.add_work 2
+    @work_pool.add_work 4
+    @work_pool.add_work 3
+
+    sleep 0.1 # allow the worker threads to run
+
+    @work_pool.shutdown(1)
+
+    assert_includes 100, @results
+    assert_includes 200, @results
+    assert_includes 300, @results
+    assert_includes 400, @results
+    assert_includes 500, @results
+  end
+
+end

--- a/test/unit/dat-worker-pool_tests.rb
+++ b/test/unit/dat-worker-pool_tests.rb
@@ -1,0 +1,128 @@
+require 'assert'
+require 'dat-worker-pool'
+
+class DatWorkerPool
+
+  class BaseTests < Assert::Context
+    desc "DatWorkerPool"
+    setup do
+      @work_pool = DatWorkerPool.new{ }
+    end
+    subject{ @work_pool }
+
+    should have_readers :logger, :spawned
+    should have_imeths :add_work, :shutdown, :despawn_worker
+    should have_imeths :work_items, :waiting
+
+  end
+
+  class WorkerBehaviorTests < BaseTests
+    desc "workers"
+    setup do
+      @work_pool = DatWorkerPool.new(1, 2, true){|work| sleep(work) }
+    end
+
+    should "be created as needed and only go up to the maximum number allowed" do
+      # the minimum should be spawned and waiting
+      assert_equal 1, @work_pool.spawned
+      assert_equal 1, @work_pool.waiting
+
+      # the minimum should be spawned, but no longer waiting
+      @work_pool.add_work 5
+      assert_equal 1, @work_pool.spawned
+      assert_equal 0, @work_pool.waiting
+
+      # an additional worker should be spawned
+      @work_pool.add_work 5
+      assert_equal 2, @work_pool.spawned
+      assert_equal 0, @work_pool.waiting
+
+      # no additional workers are spawned, the work waits to be processed
+      @work_pool.add_work 5
+      assert_equal 2, @work_pool.spawned
+      assert_equal 0, @work_pool.waiting
+    end
+
+    should "go back to waiting when they finish working" do
+      assert_equal 1, @work_pool.spawned
+      assert_equal 1, @work_pool.waiting
+
+      @work_pool.add_work 1
+      assert_equal 1, @work_pool.spawned
+      assert_equal 0, @work_pool.waiting
+
+      sleep 1 # allow the worker to run
+
+      assert_equal 1, @work_pool.spawned
+      assert_equal 1, @work_pool.waiting
+    end
+
+  end
+
+  class AddWorkAndProcessItTests < BaseTests
+    desc "add_work and process"
+    setup do
+      @result = nil
+      @work_pool = DatWorkerPool.new(1){|work| @result = (2 / work) }
+    end
+
+    should "have added the work and processed it by calling the passed block" do
+      subject.add_work 2
+      sleep 0.1 # ensure worker thread get's a chance to run
+      assert_equal 1, @result
+    end
+
+    should "swallow exceptions, so workers don't end unexpectedly" do
+      subject.add_work 0
+      worker = subject.instance_variable_get("@workers").first
+      sleep 0.1
+
+      assert_equal 1, subject.spawned
+      assert_equal 1, subject.waiting
+      assert worker.instance_variable_get("@thread").alive?
+    end
+
+  end
+
+  class ShutdownTests < BaseTests
+    desc "shutdown"
+    setup do
+      @mutex = Mutex.new
+      @finished = []
+      @work_pool = DatWorkerPool.new(1, 2, true) do |work|
+        sleep 1
+        @mutex.synchronize{ @finished << work }
+      end
+      @work_pool.add_work 'a'
+      @work_pool.add_work 'b'
+      @work_pool.add_work 'c'
+    end
+
+    should "allow any work that has been picked up to be processed" do
+      # make sure the workers haven't processed any work
+      assert_equal [], @finished
+
+      subject.shutdown(5)
+
+      # NOTE, the last work shouldn't have been processed, as it wasn't
+      # picked up by a worker
+      assert_includes     'a', @finished
+      assert_includes     'b', @finished
+      assert_not_includes 'c', @finished
+
+      assert_equal 0, subject.spawned
+      assert_equal 0, subject.waiting
+      assert_includes 'c', subject.work_items
+    end
+
+    should "timeout if the workers take to long to finish" do
+      # make sure the workers haven't processed any work
+      assert_equal [], @finished
+      assert_raises(DatWorkerPool::TimeoutError) do
+        subject.shutdown(0.1)
+      end
+    end
+
+  end
+
+end

--- a/test/unit/queue_tests.rb
+++ b/test/unit/queue_tests.rb
@@ -1,0 +1,68 @@
+require 'assert'
+require 'dat-worker-pool/queue'
+
+class DatWorkerPool::Queue
+
+  class BaseTests < Assert::Context
+    desc "DatWorkerPool::Queue"
+    setup do
+      @queue = DatWorkerPool::Queue.new
+    end
+    subject{ @queue }
+
+    should have_imeths :work_items, :push, :pop, :empty?
+    should have_imeths :wait_for_work_item, :shutdown
+
+    should "allow pushing work items onto the queue with #push" do
+      subject.push 'work'
+      assert_equal [ 'work' ], subject.work_items
+    end
+
+    should "raise an exception if trying to push work when shutdown" do
+      subject.shutdown
+      assert_raises(RuntimeError){ subject.push('work') }
+    end
+
+    should "pop work items off the queue with #pop" do
+      subject.push 'work1'
+      subject.push 'work2'
+
+      assert_equal 2, subject.work_items.size
+      assert_equal 'work1', subject.pop
+      assert_equal 1, subject.work_items.size
+      assert_equal 'work2', subject.pop
+      assert_equal 0, subject.work_items.size
+    end
+
+    should "return whether the queue is empty or not with #empty?" do
+      assert subject.empty?
+      subject.push 'work'
+      assert_not subject.empty?
+      subject.pop
+      assert subject.empty?
+    end
+
+    should "sleep a thread with #wait_for_work_item and " \
+           "wake it up with #push" do
+      thread = Thread.new{ subject.wait_for_work_item }
+      thread.join(0.1) # ensure the thread runs enough to start waiting
+      subject.push 'work'
+      # if this returns nil, then the thread never finished
+      assert_not_nil thread.join(1)
+    end
+
+    should "sleep threads with #wait_for_work_item and " \
+           "wake them all up with #shutdown" do
+      thread1 = Thread.new{ subject.wait_for_work_item }
+      thread1.join(0.1) # ensure the thread runs enough to start waiting
+      thread2 = Thread.new{ subject.wait_for_work_item }
+      thread2.join(0.1) # ensure the thread runs enough to start waiting
+      subject.shutdown
+      # if these returns nil, then the threads never finished
+      assert_not_nil thread1.join(1)
+      assert_not_nil thread2.join(1)
+    end
+
+  end
+
+end

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -1,0 +1,31 @@
+require 'assert'
+require 'dat-worker-pool/worker'
+
+require 'dat-worker-pool'
+require 'dat-worker-pool/queue'
+
+class DatWorkerPool::Worker
+
+  class BaseTests < Assert::Context
+    desc "DatWorkerPool::Worker"
+    setup do
+      @pool  = DatWorkerPool.new{ }
+      @queue = DatWorkerPool::Queue.new
+      @workers_waiting = DatWorkerPool::WorkersWaiting.new
+      @worker = DatWorkerPool::Worker.new(@pool, @queue, @workers_waiting){ }
+    end
+    subject{ @worker }
+
+    should have_imeths :shutdown, :join
+
+    should "trigger exiting it's work loop with #shutdown and " \
+           "join it's thread with #join" do
+      @queue.shutdown   # ensure the thread is not waiting on the queue
+      subject.join(0.1) # ensure the thread is looping for work
+      subject.shutdown
+      assert_not_nil subject.join(1)
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds an initial implementation of the worker pool. This logic
is pulled from DatTCP, but made into a generic component. It is
no longer tied to serving sockets, but generically processes
"work". This will allow applications to build worker pools based
on their needs and properly perform tasks using multiple threads.
