### PR TITLE
Rework `Worker` to use callbacks

### DIFF
--- a/lib/dat-worker-pool/worker.rb
+++ b/lib/dat-worker-pool/worker.rb
@@ -3,35 +3,48 @@ require 'thread'
 class DatWorkerPool
 
   class Worker
+    attr_writer :on_work, :on_waiting, :on_continuing, :on_shutdown
 
-    def initialize(pool, queue, workers_waiting, &block)
-      @pool            = pool
-      @queue           = queue
-      @workers_waiting = workers_waiting
-      @block           = block
-      @shutdown        = false
-      @thread          = Thread.new{ work_loop }
+    def initialize(queue)
+      @queue = queue
+      @on_work       = proc{ |work_item| }
+      @on_waiting    = proc{ |worker| }
+      @on_continuing = proc{ |worker| }
+      @on_shutdown   = proc{ |worker| }
+
+      @shutdown = false
+      @thread   = nil
+    end
+
+    def start
+      @thread ||= Thread.new{ work_loop }
+    end
+
+    def running?
+      @thread && @thread.alive?
     end
 
     def shutdown
       @shutdown = true
+      @queue.shutdown
     end
 
     def join(*args)
-      @thread.join(*args) if @thread
+      @thread.join(*args) if running?
     end
 
     protected
 
     def work_loop
       loop do
-        @workers_waiting.increment
+        @on_waiting.call(self)
         work_item = @queue.pop
-        @workers_waiting.decrement
-        !@shutdown ? @block.call(work_item) : break
+        @on_continuing.call(self)
+        !@shutdown ? @on_work.call(work_item) : break
       end
     ensure
-      @pool.despawn_worker(self)
+      @on_shutdown.call(self)
+      @thread = nil
     end
 
   end

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -6,23 +6,103 @@ require 'dat-worker-pool/queue'
 
 class DatWorkerPool::Worker
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "DatWorkerPool::Worker"
     setup do
-      @pool  = DatWorkerPool.new{ }
       @queue = DatWorkerPool::Queue.new
-      @workers_waiting = DatWorkerPool::WorkersWaiting.new
-      @worker = DatWorkerPool::Worker.new(@pool, @queue, @workers_waiting){ }
+      @work_done = []
+      @worker = DatWorkerPool::Worker.new(@queue).tap do |w|
+        w.on_work = proc{ |work| @work_done << work }
+      end
+    end
+    teardown do
+      @worker.shutdown
+      @worker.join
     end
     subject{ @worker }
 
-    should have_imeths :shutdown, :join
+    should have_writers :on_waiting, :on_continuing, :on_shutdown
+    should have_imeths :start, :shutdown, :join, :running?
 
-    should "trigger exiting it's work loop with #shutdown and " \
-           "join it's thread with #join" do
-      @queue.shutdown # ensure the thread is not waiting on the queue
+    should "start a thread with it's work loop with #start" do
+      thread = nil
+      assert_nothing_raised{ thread = subject.start }
+      assert_instance_of Thread, thread
+      assert thread.alive?
+      assert subject.running?
+    end
+
+    should "call the block it's passed when it get's work from the queue" do
+      subject.start
+      @queue.push 'one'
+      subject.join 0.1 # trigger the worker's thread to run
+      @queue.push 'two'
+      subject.join 0.1 # trigger the worker's thread to run
+      assert_equal [ 'one', 'two' ], @work_done
+    end
+
+    should "stop it's queue and itself, ending it's thread with #shutdown" do
+      thread = subject.start
+      subject.join 0.1 # trigger the worker's thread to run, allow it to get into it's
+                       # work loop
+      assert_nothing_raised{ subject.shutdown }
+      subject.join 0.1 # trigger the worker's thread to run, should exit
+      assert_not thread.alive?
+      assert_not subject.running?
+    end
+
+  end
+
+  class CallbacksTests < UnitTests
+    desc "callbacks"
+    setup do
+      @worker = DatWorkerPool::Worker.new(@queue).tap do |w|
+        w.on_work = proc{ |work| sleep 0.2 }
+      end
+    end
+
+    should "call the on waiting callback, yielding itself, when " \
+           "it's waiting on work from the queue" do
+      waiting, yielded_worker = nil, nil
+      subject.on_waiting = proc do |worker|
+        waiting = true
+        yielded_worker = worker
+      end
+      subject.start
+      subject.join 0.1 # trigger the worker's thread to run
+
+      assert_equal true, waiting
+      assert_equal subject, yielded_worker
+    end
+
+    should "call the on continuing callback, yielding itself, when " \
+           "it's done waiting for work from the queue" do
+      waiting, yielded_worker = nil, nil
+      subject.on_continuing = proc do |worker|
+        waiting = false
+        yielded_worker = worker
+      end
+      subject.start
+      @queue.push 'some work'
+      subject.join 0.1 # trigger the worker's thread to run
+
+      assert_equal false, waiting
+      assert_equal subject, yielded_worker
+    end
+
+    should "call the on shutdown callback, yielding itself, when " \
+           "it's shutdown and exits it's work loop" do
+      shutdown, yielded_worker = nil, nil
+      subject.on_shutdown = proc do |worker|
+        shutdown = true
+        yielded_worker = worker
+      end
+      subject.start
       subject.shutdown
-      assert_not_nil subject.join(1)
+      subject.join 0.1 # trigger the worker's thread to run
+
+      assert_equal true, shutdown
+      assert_equal subject, yielded_worker
     end
 
   end


### PR DESCRIPTION
This reworks the `Worker` to use callbacks, which reduces the
coupling of the worker with a pool. This changes `Worker` to
provide callbacks, when it's waiting, when it's done waiting and
when it's shutdown. This properly organizes the logic done
during these events in the pool and also removes the silly
public `despawn_worker` method. This "breaks" backwards
compatibility, but that method being public was never a good
implementation. This also beefs up the workers tests to
ensure it's behaving as expected.
