### PR TITLE
Modify `Worker`, better shutdown and ignore `nil` work items

### DIFF
--- a/lib/dat-worker-pool/worker.rb
+++ b/lib/dat-worker-pool/worker.rb
@@ -26,7 +26,6 @@ class DatWorkerPool
 
     def shutdown
       @shutdown = true
-      @queue.shutdown
     end
 
     def join(*args)
@@ -40,7 +39,8 @@ class DatWorkerPool
         @on_waiting.call(self)
         work_item = @queue.pop
         @on_continuing.call(self)
-        !@shutdown ? @on_work.call(work_item) : break
+        break if @shutdown
+        @on_work.call(work_item) if work_item
       end
     ensure
       @on_shutdown.call(self)


### PR DESCRIPTION
This modifies the `Worker` behavior to ignore `nil` worker items
and to use better shutdown logic.

Firstly, whenever a `nil` work item is received from the queue,
the work proc shouldn't be called. For a user of the pool, it's
not expected to receive `nil` work items and these can occur when
the worker is shutdown. The pool doesn't allow adding `nil` work,
so this is consistent.

Secondly, a `Worker` shouldn't shut down it's queue when it's
shutdown. Theoretically, it made sense for it to shut down because
otherwise a `Worker` will just wait on the queue's condition
variable. In practice this fell over because every worker would
call `queue.shutdown` which would broadcast and wakeup other
workers. This had the effect of workers looping many times and
getting `nil` work items. This is not ideal behavior and doesn't
place nicely with how the worker pool's shutdown behaves. It
flags all the workers to be shutdown and then shuts the queue down
which will make the workers exit.
