### PR TITLE
Add `WorkerPoolSpy` for testing code that uses `DatWorkerPool`

### DIFF
--- a/lib/dat-worker-pool/worker_pool_spy.rb
+++ b/lib/dat-worker-pool/worker_pool_spy.rb
@@ -1,0 +1,33 @@
+class DatWorkerPool
+
+  class WorkerPoolSpy
+    attr_reader :work_items
+    attr_reader :shutdown_called, :shutdown_timeout
+    attr_accessor :worker_available
+
+    def initialize
+      @worker_available = false
+      @work_items = []
+      @shutdown_called  = false
+      @shutdown_timeout = nil
+    end
+
+    def worker_available?
+      @worker_available
+    end
+
+    def queue_empty?
+      @work_items.empty?
+    end
+
+    def add_work(work)
+      @work_items << work if work
+    end
+
+    def shutdown(timeout)
+      @shutdown_called = true
+      @shutdown_timeout = timeout
+    end
+  end
+
+end

--- a/test/unit/worker_pool_spy_tests.rb
+++ b/test/unit/worker_pool_spy_tests.rb
@@ -1,0 +1,67 @@
+require 'assert'
+require 'dat-worker-pool/worker_pool_spy'
+
+class DatWorkerPool::WorkerPoolSpy
+
+  class UnitTests < Assert::Context
+    desc "DatWorkerPool::WorkerPoolSpy"
+    setup do
+      @worker_pool_spy = DatWorkerPool::WorkerPoolSpy.new
+    end
+    subject{ @worker_pool_spy }
+
+    should have_readers :work_items
+    should have_readers :shutdown_called, :shutdown_timeout
+    should have_accessors :worker_available
+    should have_imeths :worker_available?, :queue_empty?
+    should have_imeths :add_work, :shutdown
+
+    should "have nothing in it's work items by default" do
+      assert subject.work_items.empty?
+    end
+
+    should "not have a worker available by default" do
+      assert_equal false, subject.worker_available
+      assert_not subject.worker_available?
+    end
+
+    should "return false for shutdown called by default" do
+      assert_equal false, subject.shutdown_called
+    end
+
+    should "return `nil` for shutdown timeout by default" do
+      assert_nil subject.shutdown_timeout
+    end
+
+    should "allow setting whether a worker is available" do
+      subject.worker_available = true
+      assert_equal true, subject.worker_available
+      assert subject.worker_available?
+    end
+
+    should "allow adding work to the work items with #add_work" do
+      subject.add_work 'work'
+      assert_equal 1, subject.work_items.size
+      assert_includes 'work', subject.work_items
+    end
+
+    should "not add `nil` work to the work items with #add_work" do
+      subject.add_work nil
+      assert_equal 0, subject.work_items.size
+    end
+
+    should "return whether the work items is empty with #queue_empty?" do
+      assert_equal true, subject.queue_empty?
+      subject.add_work 'work'
+      assert_equal false, subject.queue_empty?
+    end
+
+    should "know when it's been shutdown and with what timeout" do
+      subject.shutdown(10)
+      assert subject.shutdown_called
+      assert_equal 10, subject.shutdown_timeout
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a simple worker pool spy for use as a test-double. This
is useful when testing code that uses `DatWorkerPool`. The spy
can be stubbed in as a replacement for a `DatWorkerPool` instance.
It will act similar to `DatWorkerPool` and will "track" what was
done to the worker pool.
