### PR TITLE
Allow no shutdown timeout with `WorkerPoolSpy`

### DIFF
--- a/dat-worker-pool.gemspec
+++ b/dat-worker-pool.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("SystemTimer", ["~> 1.2"])
 
-  gem.add_development_dependency("assert")
+  gem.add_development_dependency("assert", ["~> 2.12"])
 
 end

--- a/lib/dat-worker-pool/worker_pool_spy.rb
+++ b/lib/dat-worker-pool/worker_pool_spy.rb
@@ -24,7 +24,7 @@ class DatWorkerPool
       @work_items << work if work
     end
 
-    def shutdown(timeout)
+    def shutdown(timeout = nil)
       @shutdown_called = true
       @shutdown_timeout = timeout
     end

--- a/test/unit/worker_pool_spy_tests.rb
+++ b/test/unit/worker_pool_spy_tests.rb
@@ -62,6 +62,12 @@ class DatWorkerPool::WorkerPoolSpy
       assert_equal 10, subject.shutdown_timeout
     end
 
+    should "allow calling shutdown with no timeout" do
+      subject.shutdown
+      assert_true subject.shutdown_called
+      assert_nil subject.shutdown_timeout
+    end
+
   end
 
 end


### PR DESCRIPTION
This updates the `WorkerPoolSpy` to allow not passing a shutdown
timeout. This is how the real `shutdown` method works so this
should match it.

This also updates the assert dependency to the latest.

@kellyredding - Ready for review.
