### PR TITLE
Add `start` method to `DatWorkerPool`, delay spawning workers

### DIFF
--- a/lib/dat-worker-pool/queue.rb
+++ b/lib/dat-worker-pool/queue.rb
@@ -37,10 +37,18 @@ class DatWorkerPool
       @mutex.synchronize{ @work_items.empty? }
     end
 
+    def start
+      @shutdown = false
+    end
+
     # wake up any workers who are idle (because of `wait_for_work_item`)
     def shutdown
       @shutdown = true
       @mutex.synchronize{ @condition_variable.broadcast }
+    end
+
+    def shutdown?
+      @shutdown
     end
 
   end

--- a/lib/dat-worker-pool/worker_pool_spy.rb
+++ b/lib/dat-worker-pool/worker_pool_spy.rb
@@ -2,12 +2,14 @@ class DatWorkerPool
 
   class WorkerPoolSpy
     attr_reader :work_items
+    attr_reader :start_called
     attr_reader :shutdown_called, :shutdown_timeout
     attr_accessor :worker_available
 
     def initialize
       @worker_available = false
       @work_items = []
+      @start_called = false
       @shutdown_called  = false
       @shutdown_timeout = nil
     end
@@ -22,6 +24,10 @@ class DatWorkerPool
 
     def add_work(work)
       @work_items << work if work
+    end
+
+    def start
+      @start_called = true
     end
 
     def shutdown(timeout = nil)

--- a/test/system/use_worker_pool_tests.rb
+++ b/test/system/use_worker_pool_tests.rb
@@ -10,6 +10,7 @@ class UseWorkerPoolTests < Assert::Context
     @work_pool = DatWorkerPool.new(1, 2, !!ENV['DEBUG']) do |work|
       @mutex.synchronize{ @results << (work * 100) }
     end
+    @work_pool.start
   end
 
   should "be able to add work, have it processed and stop the pool" do

--- a/test/unit/queue_tests.rb
+++ b/test/unit/queue_tests.rb
@@ -11,7 +11,7 @@ class DatWorkerPool::Queue
     subject{ @queue }
 
     should have_imeths :work_items, :push, :pop, :empty?
-    should have_imeths :shutdown
+    should have_imeths :start, :shutdown, :shutdown?
 
     should "allow pushing work items onto the queue with #push" do
       subject.push 'work'
@@ -46,6 +46,14 @@ class DatWorkerPool::Queue
       assert_not subject.empty?
       subject.pop
       assert subject.empty?
+    end
+
+    should "reset its shutdown flag when started" do
+      assert_false subject.shutdown?
+      subject.shutdown
+      assert_true subject.shutdown?
+      subject.start
+      assert_false subject.shutdown?
     end
 
   end

--- a/test/unit/worker_pool_spy_tests.rb
+++ b/test/unit/worker_pool_spy_tests.rb
@@ -11,10 +11,10 @@ class DatWorkerPool::WorkerPoolSpy
     subject{ @worker_pool_spy }
 
     should have_readers :work_items
-    should have_readers :shutdown_called, :shutdown_timeout
+    should have_readers :start_called, :shutdown_called, :shutdown_timeout
     should have_accessors :worker_available
     should have_imeths :worker_available?, :queue_empty?
-    should have_imeths :add_work, :shutdown
+    should have_imeths :add_work, :start, :shutdown
 
     should "have nothing in it's work items by default" do
       assert subject.work_items.empty?
@@ -23,6 +23,10 @@ class DatWorkerPool::WorkerPoolSpy
     should "not have a worker available by default" do
       assert_equal false, subject.worker_available
       assert_not subject.worker_available?
+    end
+
+    should "return false for start called by default" do
+      assert_equal false, subject.start_called
     end
 
     should "return false for shutdown called by default" do
@@ -56,9 +60,14 @@ class DatWorkerPool::WorkerPoolSpy
       assert_equal false, subject.queue_empty?
     end
 
+    should "know when it's been started" do
+      subject.start
+      assert_true subject.start_called
+    end
+
     should "know when it's been shutdown and with what timeout" do
       subject.shutdown(10)
-      assert subject.shutdown_called
+      assert_true subject.shutdown_called
       assert_equal 10, subject.shutdown_timeout
     end
 


### PR DESCRIPTION
This adds a `start` method to `DatWorkerPool` which will keep it
from spawning any workers until the method is called. Previously,
once an instance of `DatWorkerPool` was built, it would immediately
spawn workers. This is setup for adding callbacks after a worker
pool has been initialized. With this, a worker pool can be built
and then callbacks can be added before calling `start`.

@kellyredding - Ready for review.
