### PR TITLE
Add callbacks for workers and the queue

### DIFF
--- a/lib/dat-worker-pool/worker_pool_spy.rb
+++ b/lib/dat-worker-pool/worker_pool_spy.rb
@@ -1,17 +1,32 @@
 class DatWorkerPool
 
   class WorkerPoolSpy
-    attr_reader :work_items
+    attr_reader :work_proc, :work_items
     attr_reader :start_called
     attr_reader :shutdown_called, :shutdown_timeout
+    attr_reader :on_queue_pop_callbacks, :on_queue_push_callbacks
+    attr_reader :on_worker_start_callbacks, :on_worker_shutdown_callbacks
+    attr_reader :on_worker_sleep_callbacks, :on_worker_wakeup_callbacks
+    attr_reader :before_work_callbacks, :after_work_callbacks
     attr_accessor :worker_available
 
-    def initialize
+    def initialize(&block)
+      @work_proc = block
+
       @worker_available = false
       @work_items = []
       @start_called = false
       @shutdown_called  = false
       @shutdown_timeout = nil
+
+      @on_queue_pop_callbacks       = []
+      @on_queue_push_callbacks      = []
+      @on_worker_start_callbacks    = []
+      @on_worker_shutdown_callbacks = []
+      @on_worker_sleep_callbacks    = []
+      @on_worker_wakeup_callbacks   = []
+      @before_work_callbacks        = []
+      @after_work_callbacks         = []
     end
 
     def worker_available?
@@ -34,6 +49,16 @@ class DatWorkerPool
       @shutdown_called = true
       @shutdown_timeout = timeout
     end
+
+    def on_queue_pop(&block);       @on_queue_pop_callbacks << block;       end
+    def on_queue_push(&block);      @on_queue_push_callbacks << block;      end
+    def on_worker_start(&block);    @on_worker_start_callbacks << block;    end
+    def on_worker_shutdown(&block); @on_worker_shutdown_callbacks << block; end
+    def on_worker_sleep(&block);    @on_worker_sleep_callbacks << block;    end
+    def on_worker_wakeup(&block);   @on_worker_wakeup_callbacks << block;   end
+    def before_work(&block);        @before_work_callbacks << block;        end
+    def after_work(&block);         @after_work_callbacks << block;         end
+
   end
 
 end

--- a/test/unit/worker_pool_spy_tests.rb
+++ b/test/unit/worker_pool_spy_tests.rb
@@ -6,15 +6,28 @@ class DatWorkerPool::WorkerPoolSpy
   class UnitTests < Assert::Context
     desc "DatWorkerPool::WorkerPoolSpy"
     setup do
-      @worker_pool_spy = DatWorkerPool::WorkerPoolSpy.new
+      @work_proc = proc{ 'work' }
+      @worker_pool_spy = DatWorkerPool::WorkerPoolSpy.new(&@work_proc)
     end
     subject{ @worker_pool_spy }
 
-    should have_readers :work_items
+    should have_readers :work_proc, :work_items
     should have_readers :start_called, :shutdown_called, :shutdown_timeout
+    should have_readers :on_queue_pop_callbacks, :on_queue_push_callbacks
+    should have_readers :on_worker_start_callbacks, :on_worker_shutdown_callbacks
+    should have_readers :on_worker_sleep_callbacks, :on_worker_wakeup_callbacks
+    should have_readers :before_work_callbacks, :after_work_callbacks
     should have_accessors :worker_available
     should have_imeths :worker_available?, :queue_empty?
     should have_imeths :add_work, :start, :shutdown
+    should have_imeths :on_queue_pop, :on_queue_push
+    should have_imeths :on_worker_start, :on_worker_shutdown
+    should have_imeths :on_worker_sleep, :on_worker_wakeup
+    should have_imeths :before_work, :after_work
+
+    should "know its work proc" do
+      assert_equal @work_proc, subject.work_proc
+    end
 
     should "have nothing in it's work items by default" do
       assert subject.work_items.empty?
@@ -75,6 +88,48 @@ class DatWorkerPool::WorkerPoolSpy
       subject.shutdown
       assert_true subject.shutdown_called
       assert_nil subject.shutdown_timeout
+    end
+
+    should "know its queue and worker callbacks" do
+      assert_equal [], subject.on_queue_pop_callbacks
+      callback = proc{ }
+      subject.on_queue_pop(&callback)
+      assert_equal [callback], subject.on_queue_pop_callbacks
+
+      assert_equal [], subject.on_queue_push_callbacks
+      callback = proc{ }
+      subject.on_queue_push(&callback)
+      assert_equal [callback], subject.on_queue_push_callbacks
+
+      assert_equal [], subject.on_worker_start_callbacks
+      callback = proc{ }
+      subject.on_worker_start(&callback)
+      assert_equal [callback], subject.on_worker_start_callbacks
+
+      assert_equal [], subject.on_worker_shutdown_callbacks
+      callback = proc{ }
+      subject.on_worker_shutdown(&callback)
+      assert_equal [callback], subject.on_worker_shutdown_callbacks
+
+      assert_equal [], subject.on_worker_sleep_callbacks
+      callback = proc{ }
+      subject.on_worker_sleep(&callback)
+      assert_equal [callback], subject.on_worker_sleep_callbacks
+
+      assert_equal [], subject.on_worker_wakeup_callbacks
+      callback = proc{ }
+      subject.on_worker_wakeup(&callback)
+      assert_equal [callback], subject.on_worker_wakeup_callbacks
+
+      assert_equal [], subject.before_work_callbacks
+      callback = proc{ }
+      subject.before_work(&callback)
+      assert_equal [callback], subject.before_work_callbacks
+
+      assert_equal [], subject.after_work_callbacks
+      callback = proc{ }
+      subject.after_work(&callback)
+      assert_equal [callback], subject.after_work_callbacks
     end
 
   end

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -12,7 +12,7 @@ class DatWorkerPool::Worker
       @queue = DatWorkerPool::Queue.new
       @work_done = []
       @worker = DatWorkerPool::Worker.new(@queue).tap do |w|
-        w.on_work = proc{ |work| @work_done << work }
+        w.on_work = proc{ |worker, work| @work_done << work }
       end
     end
     teardown do
@@ -22,8 +22,21 @@ class DatWorkerPool::Worker
     end
     subject{ @worker }
 
-    should have_writers :on_waiting, :on_continuing, :on_shutdown
+    should have_accessors :on_work
+    should have_accessors :on_start_callbacks, :on_shutdown_callbacks
+    should have_accessors :on_sleep_callbacks, :on_wakeup_callbacks
+    should have_accessors :before_work_callbacks, :after_work_callbacks
     should have_imeths :start, :shutdown, :join, :running?
+
+    should "default its callbacks" do
+      worker = DatWorkerPool::Worker.new(@queue)
+      assert_equal [], worker.on_start_callbacks
+      assert_equal [], worker.on_shutdown_callbacks
+      assert_equal [], worker.on_sleep_callbacks
+      assert_equal [], worker.on_wakeup_callbacks
+      assert_equal [], worker.before_work_callbacks
+      assert_equal [], worker.after_work_callbacks
+    end
 
     should "start a thread with it's work loop with #start" do
       thread = nil
@@ -60,54 +73,82 @@ class DatWorkerPool::Worker
   class CallbacksTests < UnitTests
     desc "callbacks"
     setup do
+      @call_counter = 0
+      @on_start_called_with = nil
+      @on_start_call_count = nil
+      @on_shutdown_called_with = nil
+      @on_shutdown_call_count = nil
+      @on_sleep_called_with = nil
+      @on_sleep_call_count = nil
+      @on_wakeup_called_with = nil
+      @on_wakeup_call_count = nil
+      @before_work_called_with = nil
+      @before_work_called_at = nil
+      @after_work_called_with = nil
+      @after_work_called_at = nil
       @worker = DatWorkerPool::Worker.new(@queue).tap do |w|
-        w.on_work = proc{ |work| sleep 0.2 }
+        w.on_start_callbacks    << proc do |*args|
+          @on_start_called_with = args
+          @on_start_called_at = (@call_counter += 1)
+        end
+        w.on_shutdown_callbacks << proc do |*args|
+          @on_shutdown_called_with = args
+          @on_shutdown_called_at = (@call_counter += 1)
+        end
+        w.on_sleep_callbacks    << proc do |*args|
+          @on_sleep_called_with = args
+          @on_sleep_called_at = (@call_counter += 1)
+        end
+        w.on_wakeup_callbacks   << proc do |*args|
+          @on_wakeup_called_with = args
+          @on_wakeup_called_at = (@call_counter += 1)
+        end
+        w.before_work_callbacks << proc do |*args|
+          @before_work_called_with = args
+          @before_work_called_at = (@call_counter += 1)
+        end
+        w.after_work_callbacks << proc do |*args|
+          @after_work_called_with = args
+          @after_work_called_at = (@call_counter += 1)
+        end
       end
     end
 
-    should "call the on waiting callback, yielding itself, when " \
-           "it's waiting on work from the queue" do
-      waiting, yielded_worker = nil, nil
-      subject.on_waiting = proc do |worker|
-        waiting = true
-        yielded_worker = worker
-      end
+    should "pass its self to its start, shutdown, sleep and wakupe callbacks" do
       subject.start
-      subject.join 0.1 # trigger the worker's thread to run
-
-      assert_equal true, waiting
-      assert_equal subject, yielded_worker
-    end
-
-    should "call the on continuing callback, yielding itself, when " \
-           "it's done waiting for work from the queue" do
-      waiting, yielded_worker = nil, nil
-      subject.on_continuing = proc do |worker|
-        waiting = false
-        yielded_worker = worker
-      end
-      subject.start
-      @queue.push 'some work'
-      subject.join 0.1 # trigger the worker's thread to run
-
-      assert_equal false, waiting
-      assert_equal subject, yielded_worker
-    end
-
-    should "call the on shutdown callback, yielding itself, when " \
-           "it's shutdown" do
-      shutdown, yielded_worker = nil, nil
-      subject.on_shutdown = proc do |worker|
-        shutdown = true
-        yielded_worker = worker
-      end
-      subject.start
+      @queue.push('work')
       subject.shutdown
       @queue.shutdown
-      subject.join 0.1 # trigger the worker's thread to run
 
-      assert_equal true, shutdown
-      assert_equal subject, yielded_worker
+      assert_equal [subject], @on_start_called_with
+      assert_equal [subject], @on_shutdown_called_with
+      assert_equal [subject], @on_sleep_called_with
+      assert_equal [subject], @on_wakeup_called_with
+    end
+
+    should "pass its self and work to its beofre and after work callbacks" do
+      subject.start
+      @queue.push('work')
+      subject.shutdown
+      @queue.shutdown
+
+      assert_equal [subject, 'work'], @before_work_called_with
+      assert_equal [subject, 'work'], @after_work_called_with
+    end
+
+    should "call its callbacks throughout its lifecycle" do
+      subject.start
+      assert_equal 1, @on_start_called_at
+      assert_equal 2, @on_sleep_called_at
+      @queue.push('work')
+      assert_equal 3, @on_wakeup_called_at
+      assert_equal 4, @before_work_called_at
+      assert_equal 5, @after_work_called_at
+      assert_equal 6, @on_sleep_called_at
+      subject.shutdown
+      @queue.shutdown
+      assert_equal 7, @on_wakeup_called_at
+      assert_equal 8, @on_shutdown_called_at
     end
 
   end


### PR DESCRIPTION
This adds the ability to configure callbacks on a worker pool for
its workers and queue. This allows tools using worker pool to
trigger logic as workers go through their lifecycle and when work
is added or removed from the queue. This is needed for `Qs` to only
fetch work when a worker is available and to also allow it to wait
for the worker pool's queue to empty. It will use the callbacks
to wake up its thread, when a worker is waiting or when pop is
called on the queue.

@kellyredding - Ready for review. I've tested this with `Qs` and its providing the functionality needed. I also tested it with `DatTCP` and made sure it didn't break it or hurt its performance.
