### PR TITLE
Update hard shutdown, raise shutdown error on threads

### DIFF
--- a/lib/dat-worker-pool/worker.rb
+++ b/lib/dat-worker-pool/worker.rb
@@ -28,7 +28,7 @@ class DatWorkerPool
     end
 
     def running?
-      @thread && @thread.alive?
+      !!(@thread && @thread.alive?)
     end
 
     def shutdown
@@ -39,7 +39,12 @@ class DatWorkerPool
       @thread.join(*args) if running?
     end
 
-    protected
+    def raise(*args)
+      @thread.raise(*args) if running?
+      self.join
+    end
+
+    private
 
     def work_loop
       @on_start_callbacks.each{ |p| p.call(self) }


### PR DESCRIPTION
This updates the hard shutdown logic to force worker threads down
using `Thread#raise`. This is not ideal but there isn't any other
way to force threads down if they are processing work. The hard
shutdown was and still is a "use at your own risk" feature. This
is slightly better handling because threads will be shutdown by
the raised exception and not by ruby (which uses `Thread#kill` and
is known to cause problems). It will also give error handling in
do work procs to have a chance to handle the error. This is part
of a set of changes to have better hard-shutdown logic to help
avoiding losing work.

@kellyredding - Ready for review.