### PR TITLE
Add custom error handling to workers

### DIFF
--- a/lib/dat-worker-pool/worker.rb
+++ b/lib/dat-worker-pool/worker.rb
@@ -1,10 +1,11 @@
 require 'thread'
+require 'dat-worker-pool'
 
 class DatWorkerPool
 
   class Worker
 
-    attr_accessor :on_work
+    attr_accessor :on_work, :on_error_callbacks
     attr_accessor :on_start_callbacks, :on_shutdown_callbacks
     attr_accessor :on_sleep_callbacks, :on_wakeup_callbacks
     attr_accessor :before_work_callbacks, :after_work_callbacks
@@ -12,6 +13,7 @@ class DatWorkerPool
     def initialize(queue)
       @queue = queue
       @on_work = proc{ |worker, work_item| }
+      @on_error_callbacks    = []
       @on_start_callbacks    = []
       @on_shutdown_callbacks = []
       @on_sleep_callbacks    = []
@@ -41,7 +43,6 @@ class DatWorkerPool
 
     def raise(*args)
       @thread.raise(*args) if running?
-      self.join
     end
 
     private
@@ -49,21 +50,34 @@ class DatWorkerPool
     def work_loop
       @on_start_callbacks.each{ |p| p.call(self) }
       loop do
-        @on_sleep_callbacks.each{ |p| p.call(self) }
-        work_item = @queue.pop
-        @on_wakeup_callbacks.each{ |p| p.call(self) }
         break if @shutdown
-        do_work(work_item) if work_item
+        process_work
       end
     ensure
       @on_shutdown_callbacks.each{ |p| p.call(self) }
       @thread = nil
     end
 
+    def process_work
+      @on_sleep_callbacks.each{ |p| p.call(self) }
+      work_item = @queue.pop
+      @on_wakeup_callbacks.each{ |p| p.call(self) }
+      do_work(work_item) if work_item
+    rescue ShutdownError => exception
+      handle_exception(exception, work_item)
+      raise exception
+    rescue StandardError => exception
+      handle_exception(exception, work_item)
+    end
+
     def do_work(work_item)
       @before_work_callbacks.each{ |p| p.call(self, work_item) }
       @on_work.call(self, work_item)
       @after_work_callbacks.each{ |p| p.call(self, work_item) }
+    end
+
+    def handle_exception(exception, work_item = nil)
+      @on_error_callbacks.each{ |p| p.call(self, exception, work_item) }
     end
 
   end


### PR DESCRIPTION
This updates workers to allow passing a proc for custom error
handling. This is needed because we are now using `Thread#raise`
to kill workers threads when forcing a worker pool to shutdown.
Since these exceptions can be raised at any point, we need to
allow systems to provide custom error handling when this occurs.
This expands a workers error catching to catch both standard errors
and hard shutdown errors for its entire loop. For hard shutdown
errors, after custom error handling is called, the worker will
reraise the error which ensures that thread will exit from the
exception.

This also fixes a small bug where it was possible that work
could be pulled off of the queue but could be shutdown before
processing it. This would result in the work being lost. Now if
work is pulled off, it will attempt to process it always. If the
hard shutdown raises at this point then the custom error handling
has a chance to deal with the work.

@kellyredding - Ready for review.