### PR TITLE
Consistently organize methods, cleanup comments, simplify timeout

### DIFF
--- a/lib/dat-worker-pool/worker.rb
+++ b/lib/dat-worker-pool/worker.rb
@@ -29,12 +29,12 @@ class DatWorkerPool
       @thread ||= Thread.new{ work_loop }
     end
 
-    def running?
-      !!(@thread && @thread.alive?)
-    end
-
     def shutdown
       @shutdown = true
+    end
+
+    def running?
+      !!(@thread && @thread.alive?)
     end
 
     def join(*args)
@@ -51,14 +51,14 @@ class DatWorkerPool
       @on_start_callbacks.each{ |p| p.call(self) }
       loop do
         break if @shutdown
-        process_work
+        fetch_and_do_work
       end
     ensure
       @on_shutdown_callbacks.each{ |p| p.call(self) }
       @thread = nil
     end
 
-    def process_work
+    def fetch_and_do_work
       @on_sleep_callbacks.each{ |p| p.call(self) }
       work_item = @queue.pop
       @on_wakeup_callbacks.each{ |p| p.call(self) }

--- a/test/unit/dat-worker-pool_tests.rb
+++ b/test/unit/dat-worker-pool_tests.rb
@@ -15,7 +15,7 @@ class DatWorkerPool
     should have_readers :on_worker_start_callbacks, :on_worker_shutdown_callbacks
     should have_readers :on_worker_sleep_callbacks, :on_worker_wakeup_callbacks
     should have_readers :before_work_callbacks, :after_work_callbacks
-    should have_imeths :add_work, :start, :shutdown, :despawn_worker
+    should have_imeths :add_work, :start, :shutdown
     should have_imeths :work_items, :waiting
     should have_imeths :worker_available?, :all_spawned_workers_are_busy?
     should have_imeths :reached_max_workers?


### PR DESCRIPTION
This is a set of cleanups that doesn't change any functionality.
These changes are part of keeping the code easier to maintain and
understand. It has gone through a few rounds of fairly significant
changes so this seeks to cleanup the code that has been added and
changed.

It organizes methods so that they are more consistent.
Specifically, this moves the start/shutdown methods to the top for
the worker pool, queue and workers. This also simplifies some of
the comments explaining some of the more strange or confusing parts
of the code.

Finally, this simplifies the shutdown timeout handling. The
optional timeout has been simplified and the re-raise logic
removed. It now also raises a timeout error which then triggers
the worker pool to raise a shutdown error. This makes more sense
than the timeout raising a shutdown error directly because the
timeout triggers the hard shutdown (aka the shutdown error).

@kellyredding - Ready for review.