### PR TITLE
Add on worker error callback to `WorkerPoolSpy`

### DIFF
--- a/lib/dat-worker-pool/worker_pool_spy.rb
+++ b/lib/dat-worker-pool/worker_pool_spy.rb
@@ -1,11 +1,13 @@
 class DatWorkerPool
 
   class WorkerPoolSpy
+
     attr_reader :min_workers, :max_workers, :debug
     attr_reader :work_proc, :work_items
     attr_reader :start_called
     attr_reader :shutdown_called, :shutdown_timeout
     attr_reader :on_queue_pop_callbacks, :on_queue_push_callbacks
+    attr_reader :on_worker_error_callbacks
     attr_reader :on_worker_start_callbacks, :on_worker_shutdown_callbacks
     attr_reader :on_worker_sleep_callbacks, :on_worker_wakeup_callbacks
     attr_reader :before_work_callbacks, :after_work_callbacks
@@ -25,6 +27,7 @@ class DatWorkerPool
 
       @on_queue_pop_callbacks       = []
       @on_queue_push_callbacks      = []
+      @on_worker_error_callbacks    = []
       @on_worker_start_callbacks    = []
       @on_worker_shutdown_callbacks = []
       @on_worker_sleep_callbacks    = []
@@ -33,12 +36,13 @@ class DatWorkerPool
       @after_work_callbacks         = []
     end
 
-    def worker_available?
-      @worker_available
+    def start
+      @start_called = true
     end
 
-    def queue_empty?
-      @work_items.empty?
+    def shutdown(timeout = nil)
+      @shutdown_called = true
+      @shutdown_timeout = timeout
     end
 
     def add_work(work)
@@ -53,23 +57,23 @@ class DatWorkerPool
       work
     end
 
-    def start
-      @start_called = true
+    def queue_empty?
+      @work_items.empty?
     end
 
-    def shutdown(timeout = nil)
-      @shutdown_called = true
-      @shutdown_timeout = timeout
+    def worker_available?
+      @worker_available
     end
 
-    def on_queue_pop(&block);       @on_queue_pop_callbacks << block;       end
-    def on_queue_push(&block);      @on_queue_push_callbacks << block;      end
-    def on_worker_start(&block);    @on_worker_start_callbacks << block;    end
+    def on_queue_pop(&block);       @on_queue_pop_callbacks       << block; end
+    def on_queue_push(&block);      @on_queue_push_callbacks      << block; end
+    def on_worker_error(&block);    @on_worker_error_callbacks    << block; end
+    def on_worker_start(&block);    @on_worker_start_callbacks    << block; end
     def on_worker_shutdown(&block); @on_worker_shutdown_callbacks << block; end
-    def on_worker_sleep(&block);    @on_worker_sleep_callbacks << block;    end
-    def on_worker_wakeup(&block);   @on_worker_wakeup_callbacks << block;   end
-    def before_work(&block);        @before_work_callbacks << block;        end
-    def after_work(&block);         @after_work_callbacks << block;         end
+    def on_worker_sleep(&block);    @on_worker_sleep_callbacks    << block; end
+    def on_worker_wakeup(&block);   @on_worker_wakeup_callbacks   << block; end
+    def before_work(&block);        @before_work_callbacks        << block; end
+    def after_work(&block);         @after_work_callbacks         << block; end
 
   end
 

--- a/test/unit/worker_pool_spy_tests.rb
+++ b/test/unit/worker_pool_spy_tests.rb
@@ -14,6 +14,7 @@ class DatWorkerPool::WorkerPoolSpy
     should have_readers :work_proc, :work_items
     should have_readers :start_called, :shutdown_called, :shutdown_timeout
     should have_readers :on_queue_pop_callbacks, :on_queue_push_callbacks
+    should have_readers :on_worker_error_callbacks
     should have_readers :on_worker_start_callbacks, :on_worker_shutdown_callbacks
     should have_readers :on_worker_sleep_callbacks, :on_worker_wakeup_callbacks
     should have_readers :before_work_callbacks, :after_work_callbacks
@@ -21,6 +22,7 @@ class DatWorkerPool::WorkerPoolSpy
     should have_imeths :worker_available?, :queue_empty?
     should have_imeths :add_work, :start, :shutdown
     should have_imeths :on_queue_pop, :on_queue_push
+    should have_imeths :on_worker_error
     should have_imeths :on_worker_start, :on_worker_shutdown
     should have_imeths :on_worker_sleep, :on_worker_wakeup
     should have_imeths :before_work, :after_work
@@ -100,6 +102,11 @@ class DatWorkerPool::WorkerPoolSpy
       callback = proc{ }
       subject.on_queue_push(&callback)
       assert_equal [callback], subject.on_queue_push_callbacks
+
+      assert_equal [], subject.on_worker_error_callbacks
+      callback = proc{ }
+      subject.on_worker_error(&callback)
+      assert_equal [callback], subject.on_worker_error_callbacks
 
       assert_equal [], subject.on_worker_start_callbacks
       callback = proc{ }


### PR DESCRIPTION
This updates the worker pool spy to have the same interface as the
real worker pool. This adds the on worker error callback methods
to it. This should've been done when they were added to the main
worker pool but was accidentally forgotten. This ensures the spy
is still a good stand-in for a real pool.

This also does some minor cleanups to the spy to keeps its methods
ordered similarly to the real pool. This should've also been done
when the real pools methods order was updated but it was also
forgotten.

@kellyredding - Ready for review. Noticed I forgot to update the spy when I brought it into Qs and tried to run the tests.