### PR TITLE
Fix hard shutdown error always being raised by worker pool

### DIFF
--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -190,6 +190,8 @@ class DatWorkerPool::Worker
       @queue.push('work')
       assert_equal [subject, exception, 'work'], @on_error_called_with
       assert_false thread.alive?
+      # ensure the shutdown error is handled and isn't thrown when we join
+      assert_nothing_raised{ thread.join }
     end
 
   end


### PR DESCRIPTION
This fixes a bug that was hidden by the test suite. Previously, the
worker pool, when forced to shutdown, would always raise a
`ShutdownError`. The tests hid this because they ran the worker
pool in debug mode, which is supposed to reraise the shutdown
error. The issue is if an exception is raised in a thread with
`Thread#raise` and its never rescued, it will be thrown when
joining the thread. This can cause the worker pool to not properly
shutdown all of its workers.

To fix this, the worker pool rescues any errors when joining its
threads and the worker will rescue the shutdown errors. The benefit
of having the worker rescue the shutdown error is it allows the
worker shutdown procs to be called. The worker pool needs to rescue
when joining the workers because its possible that the shutdown
error is raised in the workers ensure block.

@kellyredding - Ready for review. As mentioned, the test suite was hiding this but I ran into it in Qs.