### PR TITLE
Remove min and max workers, always spawn a consistent number of workers

### DIFF
--- a/lib/dat-worker-pool/worker_pool_spy.rb
+++ b/lib/dat-worker-pool/worker_pool_spy.rb
@@ -2,7 +2,7 @@ class DatWorkerPool
 
   class WorkerPoolSpy
 
-    attr_reader :min_workers, :max_workers, :debug
+    attr_reader :num_workers, :debug
     attr_reader :work_proc, :work_items
     attr_reader :start_called
     attr_reader :shutdown_called, :shutdown_timeout
@@ -13,11 +13,10 @@ class DatWorkerPool
     attr_reader :before_work_callbacks, :after_work_callbacks
     attr_accessor :worker_available
 
-    def initialize(min = 0, max = 1, debug = false, &block)
-      @min_workers  = min
-      @max_workers  = max
-      @debug        = debug
-      @work_proc    = block
+    def initialize(num_workers = 1, debug = false, &block)
+      @num_workers = num_workers
+      @debug       = debug
+      @work_proc   = block
 
       @worker_available = false
       @work_items = []

--- a/test/system/use_worker_pool_tests.rb
+++ b/test/system/use_worker_pool_tests.rb
@@ -7,7 +7,7 @@ class UseWorkerPoolTests < Assert::Context
   setup do
     @mutex = Mutex.new
     @results = []
-    @work_pool = DatWorkerPool.new(1, 2, !!ENV['DEBUG']) do |work|
+    @work_pool = DatWorkerPool.new(2, !!ENV['DEBUG']) do |work|
       @mutex.synchronize{ @results << (work * 100) }
     end
     @work_pool.start

--- a/test/unit/worker_pool_spy_tests.rb
+++ b/test/unit/worker_pool_spy_tests.rb
@@ -11,6 +11,7 @@ class DatWorkerPool::WorkerPoolSpy
     end
     subject{ @worker_pool_spy }
 
+    should have_readers :num_workers, :debug
     should have_readers :work_proc, :work_items
     should have_readers :start_called, :shutdown_called, :shutdown_timeout
     should have_readers :on_queue_pop_callbacks, :on_queue_push_callbacks


### PR DESCRIPTION
This changes worker pools to alway spawn a set number of workers.
They no longer have a min and max setting. This simplifies the
worker pools logic and is setup for allowing custom queue classes.

Previously, dat worker pool would allow specifying a min and max
number of workers. When work was added it would see if a worker
was available to process it, and if not, spawn another worker if
it hadn't reached the max. With allowing custom queue classes, this
option no longer makes as much sense. For some custom queue classes
they won't define a `push` method because they will not have work
directly pushed onto them. Instead they will get their work from
redis or a socket. In this case, there is no logical place to
trigger spawning additional workers. If we left min and max number
of workers in, you would have to know to always configure the min
and max the same if you had a queue that couldn't take advantage
of it. Rather than deal with this and the added confusion, its
simpler to remove the logic.

@kellyredding - Ready for review.