### PR TITLE
Fix infinite loop bug when force shutting down

### DIFF
--- a/lib/dat-worker-pool.rb
+++ b/lib/dat-worker-pool.rb
@@ -117,13 +117,13 @@ class DatWorkerPool
   #   shutdown is raised and not rescued (for example, in the workers ensure),
   #   then it won't cause the forced shutdown to end prematurely.
   def force_shutdown(timeout, backtrace)
-    error = ShutdownError.new "Timed out shutting down the worker pool " \
-                              "(#{timeout} seconds)."
+    error = ShutdownError.new "Timed out shutting down (#{timeout} seconds)."
     error.set_backtrace(backtrace)
     until @workers.empty?
       worker = @workers.first
       worker.raise(error)
       worker.join rescue false
+      @workers.delete(worker)
     end
     raise error if @debug
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,4 +7,6 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
+require 'test/support/factory'
+
 # TODO: put test helpers here...

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,0 +1,15 @@
+require 'assert/factory'
+
+module Factory
+  extend Assert::Factory
+
+  def self.exception(klass = nil, message = nil)
+    klass ||= StandardError
+    message ||= Factory.text
+    exception = nil
+    begin; raise(klass, message); rescue klass => exception; end
+    exception.set_backtrace(nil) if Factory.boolean
+    exception
+  endg
+
+end

--- a/test/system/use_worker_pool_tests.rb
+++ b/test/system/use_worker_pool_tests.rb
@@ -1,34 +1,75 @@
 require 'assert'
 require 'dat-worker-pool'
 
-class UseWorkerPoolTests < Assert::Context
+class DatWorkerPool
 
-  desc "defining a custom worker pool"
-  setup do
-    @mutex = Mutex.new
-    @results = []
-    @work_pool = DatWorkerPool.new(2, !!ENV['DEBUG']) do |work|
-      @mutex.synchronize{ @results << (work * 100) }
-    end
-    @work_pool.start
+  class SystemTests < Assert::Context
+    desc "DatWorkerPool"
+
   end
 
-  should "be able to add work, have it processed and stop the pool" do
-    @work_pool.add_work 1
-    @work_pool.add_work 5
-    @work_pool.add_work 2
-    @work_pool.add_work 4
-    @work_pool.add_work 3
+  class UseWorkerPoolTests < SystemTests
+    setup do
+      @mutex = Mutex.new
+      @results = []
+      @work_pool = DatWorkerPool.new(2, !!ENV['DEBUG']) do |work|
+        @mutex.synchronize{ @results << (work * 100) }
+      end
+      @work_pool.start
+    end
 
-    sleep 0.1 # allow the worker threads to run
+    should "be able to add work, have it processed and stop the pool" do
+      @work_pool.add_work 1
+      @work_pool.add_work 5
+      @work_pool.add_work 2
+      @work_pool.add_work 4
+      @work_pool.add_work 3
 
-    @work_pool.shutdown(1)
+      sleep 0.1 # allow the worker threads to run
 
-    assert_includes 100, @results
-    assert_includes 200, @results
-    assert_includes 300, @results
-    assert_includes 400, @results
-    assert_includes 500, @results
+      @work_pool.shutdown(1)
+
+      assert_includes 100, @results
+      assert_includes 200, @results
+      assert_includes 300, @results
+      assert_includes 400, @results
+      assert_includes 500, @results
+    end
+
+  end
+
+  class ForcedShutdownSystemTests < SystemTests
+    desc "forced shutdown"
+    setup do
+      @mutex = Mutex.new
+      @finished = []
+      @max_workers = 2
+      # don't put leave the worker pool in debug mode
+      @work_pool = DatWorkerPool.new(@max_workers, false) do |work|
+        begin
+          sleep 1
+        rescue ShutdownError => error
+          @mutex.synchronize{ @finished << error }
+          raise error # re-raise it otherwise worker won't shutdown
+        end
+      end
+      @work_pool.start
+      @work_pool.add_work 'a'
+      @work_pool.add_work 'b'
+      @work_pool.add_work 'c'
+    end
+    subject{ @work_pool }
+
+    should "force workers to shutdown if they take to long to finish" do
+      # make sure the workers haven't processed any work
+      assert_equal [], @finished
+      subject.shutdown(0.1)
+      assert_equal @max_workers, @finished.size
+      @finished.each do |error|
+        assert_instance_of DatWorkerPool::ShutdownError, error
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
This fixes a rare but possible infinite loop bug when force
shutting down a worker pool.

Force shutting down raises shutdown errors in the worker pools
worker threads. This causes them to error and exit out. Its
possible that the worker thread is in a state when the shutdown
error is raised it doesn't catch it (the `ensure` block in its
`work_loop` method for example.). If this happens, the previous
logic would catch and ignore the error but wouldn't remove the
worker from its collection. Its `until` loop would iterate and
pick the same worker and infinitely repeat. This fixes it by
manually deleting the worker from the collection at the end of
the loop (when it normally shuts down it deletes itself from the
collection).

This also adds tests for this behavior and changes the forced
shutdown tests. They now use fake/spy workers to setup the specific
scenarios instead of trying to create the scenario by manipulating
actual threads. This is part of an effort to make dat worker pools
unit tests cleaner and less "systemy". As part of this, the
previous forced shutdown tests were moved into the system tests
(because they manipulate threads and try to craft specific
scenarios).

Finally, this also removes "worker pool" from the shutdown error
raised when forcing the worker pool to shutdown. This error can
be caught and reported on in systems built on dat worker pool and
I'd rather the message not reveal anything about dat worker pool.

@kellyredding - Ready for review.

Related to #14 