### PR TITLE
Update `DatWorkerPool` to be initialized with options hash

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,6 +7,12 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
+require 'pathname'
+ROOT_PATH = Pathname.new(File.expand_path('../..', __FILE__))
+
+require 'logger'
+TEST_LOGGER = Logger.new(ROOT_PATH.join("log/test.log"))
+
 require 'test/support/factory'
 
 # TODO: put test helpers here...


### PR DESCRIPTION
This updates `DatWorkerPool` to be initialized with an options
hash. This is better than a list of ordered arguments because its
more flexibile and can expand in the future. This is also setup
for allowing a queue and worker class to be passed when its
initialized. For now, the do work proc is being passed, which is
not the best interface but this will be changed once a worker
class can be passed.

This also changes the worker pool to not take a debug flag but
instead take a logger. This provides more flexibility for logging
and doesn't force only logging to stdout. The default is a null
logger which is a no-op (the methods do nothing) instead of using
`/dev/null` (because this isn't compatible on all systems).

This also adds validation for the number of workers to ensure it
is valid. This was mentioned as a nice cleanup when it took min and
max workers.

Finally, this cleans up the dat worker pool unit tests to use the
new interface, adds comments for future changes related to passing
a queue and worker class and moves some of them to system tests.
This is part of updating the tests to more clearly divide unit and
system and is also setup for passing a queue and worker class.

@kellyredding - Ready for review. So this is an intermediate step to passing a queue and worker class. It has some parts I don't like (passing a do work proc) but since I know they are going to change I didn't worry about them.

Related to #14