### PR TITLE
Rename `Queue` to `DefaultQueue` 

### DIFF
--- a/lib/dat-worker-pool.rb
+++ b/lib/dat-worker-pool.rb
@@ -3,7 +3,7 @@ require 'system_timer'
 require 'thread'
 
 require 'dat-worker-pool/version'
-require 'dat-worker-pool/queue'
+require 'dat-worker-pool/default_queue'
 require 'dat-worker-pool/worker'
 
 class DatWorkerPool
@@ -28,7 +28,7 @@ class DatWorkerPool
       raise ArgumentError, "number of workers must be at least #{MIN_WORKERS}"
     end
 
-    @queue           = Queue.new
+    @queue           = DatWorkerPool::DefaultQueue.new
     @workers_waiting = WorkersWaiting.new
 
     @mutex   = Mutex.new

--- a/lib/dat-worker-pool/default_queue.rb
+++ b/lib/dat-worker-pool/default_queue.rb
@@ -2,7 +2,7 @@ require 'thread'
 
 class DatWorkerPool
 
-  class Queue
+  class DefaultQueue
 
     attr_accessor :on_push_callbacks, :on_pop_callbacks
 

--- a/test/unit/dat-worker-pool_tests.rb
+++ b/test/unit/dat-worker-pool_tests.rb
@@ -46,7 +46,7 @@ class DatWorkerPool
     should "default its attributes" do
       assert_equal DEFAULT_NUM_WORKERS, subject.num_workers
       assert_instance_of NullLogger, subject.logger
-      assert_instance_of Queue, subject.queue
+      assert_instance_of DatWorkerPool::DefaultQueue, subject.queue
 
       assert_equal [], subject.on_worker_error_callbacks
       assert_equal [], subject.on_worker_start_callbacks

--- a/test/unit/default_queue_tests.rb
+++ b/test/unit/default_queue_tests.rb
@@ -1,12 +1,12 @@
 require 'assert'
-require 'dat-worker-pool/queue'
+require 'dat-worker-pool/default_queue'
 
-class DatWorkerPool::Queue
+class DatWorkerPool::DefaultQueue
 
   class UnitTests < Assert::Context
-    desc "DatWorkerPool::Queue"
+    desc "DatWorkerPool::DefaultQueue"
     setup do
-      @queue = DatWorkerPool::Queue.new
+      @queue = DatWorkerPool::DefaultQueue.new
     end
     subject{ @queue }
 

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -2,14 +2,14 @@ require 'assert'
 require 'dat-worker-pool/worker'
 
 require 'dat-worker-pool'
-require 'dat-worker-pool/queue'
+require 'dat-worker-pool/default_queue'
 
 class DatWorkerPool::Worker
 
   class UnitTests < Assert::Context
     desc "DatWorkerPool::Worker"
     setup do
-      @queue = DatWorkerPool::Queue.new
+      @queue = DatWorkerPool::DefaultQueue.new
       @work_done = []
       @worker = DatWorkerPool::Worker.new(@queue).tap do |w|
         w.on_work = proc{ |worker, work| @work_done << work }


### PR DESCRIPTION
This renames the `Queue` class to `DefaultQueue`. This is setup for
having a base `Queue` mixin that can be used to define custom
queues for dat worker pool. This renames the existing queue as
a first step so the `Queue` name is now available. The
`DefaultQueue` will continue to be provided by dat worker pool and
will also continue to be the default for a worker pool.

@kellyredding - Ready for review. This will make the PR where I add a `Queue` mixin easier to read. Otherwise git will diff the memory queue logic with the queue mixin logic.