### PR TITLE
Add `Queue` mixin for defining custom queues

### DIFF
--- a/lib/dat-worker-pool.rb
+++ b/lib/dat-worker-pool.rb
@@ -4,6 +4,7 @@ require 'thread'
 
 require 'dat-worker-pool/version'
 require 'dat-worker-pool/default_queue'
+require 'dat-worker-pool/queue'
 require 'dat-worker-pool/worker'
 
 class DatWorkerPool
@@ -83,11 +84,11 @@ class DatWorkerPool
     @workers_waiting.count > 0
   end
 
-  def on_queue_pop_callbacks;  @queue.on_pop_callbacks;  end
   def on_queue_push_callbacks; @queue.on_push_callbacks; end
+  def on_queue_pop_callbacks;  @queue.on_pop_callbacks;  end
 
-  def on_queue_pop(&block);  @queue.on_pop_callbacks  << block; end
-  def on_queue_push(&block); @queue.on_push_callbacks << block; end
+  def on_queue_push(&block); @queue.on_push(&block); end
+  def on_queue_pop(&block);  @queue.on_pop(&block);  end
 
   def on_worker_error(&block);    @on_worker_error_callbacks    << block; end
   def on_worker_start(&block);    @on_worker_start_callbacks    << block; end

--- a/lib/dat-worker-pool/queue.rb
+++ b/lib/dat-worker-pool/queue.rb
@@ -1,0 +1,70 @@
+class DatWorkerPool
+
+  module Queue
+
+    def start
+      @running = true
+      start!
+    end
+
+    def shutdown
+      @running = false
+      shutdown!
+    end
+
+    def running?
+      !!@running
+    end
+
+    def shutdown?
+      !self.running?
+    end
+
+    def push(*args)
+      raise "Unable to add work when shut down" if self.shutdown?
+      push!(*args)
+    end
+
+    def pop
+      return if self.shutdown?
+      pop!
+    end
+
+    private
+
+    # overwrite this method to add custom start logic; this is a no-op by
+    # default because we don't require a queue to have custom start logic
+    def start!; end
+
+    # overwrite this method to add custom shutdown logic; this is a no-op by
+    # default because we don't require a queue to have custom shutdown logic;
+    # more than likely you will want to use this to "wakeup" worker threads
+    # that are sleeping waiting to pop work from the queue (see the default
+    # queue for an example using mutexes and condition variables)
+    def shutdown!; end
+
+    # overwrite this method to add custom push logic; this doesn't have to be
+    # overwritten but if it isn't, you will not be able to add work items using
+    # the queue (and the `add_work` method on `DatWorkerPool` will not work);
+    # more than likely this should add work to the queue and "signal" the
+    # workers so they know to process it (see the default queue for an example
+    # using mutexes and condition variables)
+    def push!(*args)
+      raise NotImplementedError
+    end
+
+    # overwrite this method to add custom pop logic; this has to be overwritten
+    # or the workers will not be able to get work that needs to be processed;
+    # this is intended to sleep the worker threads (see the default queue for an
+    # example using mutexes and condition variables); if this returns `nil` the
+    # workers will ignore it and go back to sleep, `nil` is not a valid work
+    # item to process; also check if the queue is shutdown when waking up
+    # workers, you probably don't want to hand-off work while everything is
+    # shutting down
+    def pop!
+      raise NotImplementedError
+    end
+
+  end
+
+end

--- a/test/unit/dat-worker-pool_tests.rb
+++ b/test/unit/dat-worker-pool_tests.rb
@@ -83,14 +83,15 @@ class DatWorkerPool
 
     # TODO - stub queue once we can pass a queue instance to worker pool
     should "know if its queue is empty or not" do
-      assert_equal true, subject.queue_empty?
-      subject.add_work Factory.string
-      assert_equal false, subject.queue_empty?
+      assert_true subject.queue_empty?
+      subject.queue.start
+      subject.queue.push Factory.string
+      assert_false subject.queue_empty?
     end
 
     # TODO - once we pass queue, test shutdown changes on queue
     should "start its queue when its started" do
-      assert_false subject.queue.shutdown?
+      assert_true subject.queue.shutdown?
       subject.start
       assert_false subject.queue.shutdown?
       subject.shutdown

--- a/test/unit/queue_tests.rb
+++ b/test/unit/queue_tests.rb
@@ -1,0 +1,116 @@
+require 'assert'
+require 'dat-worker-pool/queue'
+
+module DatWorkerPool::Queue
+
+  class UnitTests < Assert::Context
+    desc "DatWorkerPool::Queue"
+    setup do
+      @queue_class = Class.new do
+        include DatWorkerPool::Queue
+
+        attr_reader :start_called, :shutdown_called
+        attr_reader :push_called_with
+        attr_accessor :pop_result
+
+        def initialize
+          @start_called     = false
+          @shutdown_called  = false
+          @push_called_with = nil
+          @pop_result       = nil
+        end
+
+        def start!;    @start_called = true;    end
+        def shutdown!; @shutdown_called = true; end
+
+        def push!(*args); @push_called_with = args; end
+        def pop!; @pop_result; end
+      end
+    end
+    subject{ @queue_class }
+
+    should "raise a not implemented error for `push` and `pop` by default" do
+      queue_class = Class.new{ include DatWorkerPool::Queue }
+      queue = queue_class.new.tap(&:start)
+
+      assert_raises(NotImplementedError){ queue.push(Factory.string) }
+      assert_raises(NotImplementedError){ queue.pop }
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @queue = @queue_class.new
+    end
+    subject{ @queue }
+
+    should have_imeths :start, :shutdown, :running?, :shutdown?
+    should have_imeths :push, :pop
+
+    should "set its flags using `start` and `shutdown`" do
+      assert_false subject.running?
+      assert_true  subject.shutdown?
+      subject.start
+      assert_true  subject.running?
+      assert_false subject.shutdown?
+      subject.shutdown
+      assert_false subject.running?
+      assert_true  subject.shutdown?
+    end
+
+    should "call `start!` using `start`" do
+      assert_false subject.start_called
+      subject.start
+      assert_true subject.start_called
+    end
+
+    should "call `shutdown!` using `shutdown`" do
+      assert_false subject.shutdown_called
+      subject.shutdown
+      assert_true subject.shutdown_called
+    end
+
+    should "raise an error if `push` is called when the queue isn't running" do
+      assert_false subject.running?
+      assert_raise(RuntimeError){ subject.push(Factory.string) }
+      subject.start
+      assert_nothing_raised{ subject.push(Factory.string) }
+      subject.shutdown
+      assert_raise(RuntimeError){ subject.push(Factory.string) }
+    end
+
+    should "call `push!` using `push`" do
+      subject.start
+
+      work_item = Factory.string
+      subject.push(work_item)
+      assert_equal [work_item], subject.push_called_with
+
+      args = Factory.integer(3).times.map{ Factory.string }
+      subject.push(*args)
+      assert_equal args, subject.push_called_with
+    end
+
+    should "return nothing if `pop` is called when the queue isn't running" do
+      subject.pop_result = Factory.string
+      assert_false subject.running?
+      assert_nil subject.pop
+      subject.start
+      assert_not_nil subject.pop
+      subject.shutdown
+      assert_nil subject.pop
+    end
+
+    should "call `pop!` using `pop`" do
+      subject.start
+      subject.pop_result = Factory.string
+
+      value = subject.pop
+      assert_equal subject.pop_result, value
+    end
+
+  end
+
+end

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -9,7 +9,7 @@ class DatWorkerPool::Worker
   class UnitTests < Assert::Context
     desc "DatWorkerPool::Worker"
     setup do
-      @queue = DatWorkerPool::DefaultQueue.new
+      @queue = DatWorkerPool::DefaultQueue.new.tap(&:start)
       @work_done = []
       @worker = DatWorkerPool::Worker.new(@queue).tap do |w|
         w.on_work = proc{ |worker, work| @work_done << work }


### PR DESCRIPTION
This adds a `Queue` mixin which defines the interface needed to
define a custom queue for dat-worker-pool. This also updates the
`DefaultQueue` to use it.

The `Queue` mixin defines the interface that dat-worker-pool
expects its queues to have. It is intended to be mixed into a
queue class and have its `!` methods overwritten. It provides some
default logic for handling starting and shutting down the queue
but doesn't provide any "queue" logic. A custom queue class is
responsible for the "queue" logic and also making it thread-safe.

With the new mixin, queues now use a running flag instead of a
shutdown flag. The biggest difference with this change is that
the default state of a queue is not running or shutdown. This is
more correct, a queue `start` method should be called before using
the queue, but caused some of the tests to have to start queues
before using them.

This also updates the `DefaultQueue` to use the `Queue` mixin and
also be an example of how to define a custom queue. This mostly
involved removing duplicate logic that the `Queue` now provides
and updating the default queues logic to use the queue mixin
interface. This doesn't change the functionality of the default
queue just how its defined.

@kellyredding - Ready for review.