### PR TITLE
Cleanup `DefaultQueue` unit tests; add edge case testing

### DIFF
--- a/test/support/thread_spies.rb
+++ b/test/support/thread_spies.rb
@@ -1,0 +1,44 @@
+require 'thread'
+
+class MutexSpy < Mutex
+  attr_reader :synchronize_called
+
+  def initialize
+    @synchronize_called = false
+    super
+  end
+
+  def synchronize
+    @synchronize_called = true
+    super
+  end
+end
+
+class ConditionVariableSpy < ConditionVariable
+  attr_reader :signal_called, :broadcast_called
+  attr_reader :wait_called_on, :wait_call_count
+
+  def initialize
+    @signal_called    = false
+    @broadcast_called = false
+    @wait_called_on   = nil
+    @wait_call_count  = 0
+    super
+  end
+
+  def signal
+    @signal_called = true
+    super
+  end
+
+  def broadcast
+    @broadcast_called = true
+    super
+  end
+
+  def wait(mutex)
+    @wait_called_on  = mutex
+    @wait_call_count += 1
+    super
+  end
+end


### PR DESCRIPTION
This cleans up the default queue unit tests to use our latest
conventions and test mutex/condition variable behavior. This also
includes more edge case testing with the default queue and threads.
This is to improve the test suite and keep it maintained.

@kellyredding - Ready for review.

Related to #14