### PR TITLE
Allow passing a queue to a worker pool

### DIFF
--- a/test/system/use_worker_pool_tests.rb
+++ b/test/system/use_worker_pool_tests.rb
@@ -113,7 +113,7 @@ class DatWorkerPool
       assert_not_includes 'c', @finished
 
       assert_equal 0, subject.waiting
-      assert_includes 'c', subject.work_items
+      assert_includes 'c', subject.queue.work_items
     end
 
     should "allow jobs to finish by not providing a shutdown timeout" do


### PR DESCRIPTION
This updates `DatWorkerPool` to allow passing a queue to it. This
with the queue mixin will allow using a custom queue with a worker
pool. This will allow specific systems to use their own custom
queue logic and let them still use the worker pool.

A `queue` option can now be passed when initializing a dat worker
pool instance. This will set the queue that the worker pool uses.
If a queue option is not provided it will build the default queue
as it previously did.

Now that a custom queue can be provided, this removes the worker
pool methods that expected the default queue. The worker pool no
longer demeters the queues work items, whether or not its empty or
its callbacks. Custom queues may not provide these methods so the
worker pool can't always expect them.

This also updates some of the dat worker pool unit tests. Now that
we can pass a custom queue some of its tests could be simplified
by using a custom queue.

@kellyredding - Ready for review.

Related to #14 