### PR TITLE
Change `DefaultQueue` callbacks, pass the queue and work item

### DIFF
--- a/lib/dat-worker-pool/default_queue.rb
+++ b/lib/dat-worker-pool/default_queue.rb
@@ -42,7 +42,7 @@ class DatWorkerPool
         @work_items << work_item
         @cond_var.signal
       end
-      @on_push_callbacks.each(&:call)
+      @on_push_callbacks.each{ |p| p.call(self, work_item) }
     end
 
     # check if the queue is empty, if so sleep (`@cond_var.wait(@mutex)`) until
@@ -56,7 +56,7 @@ class DatWorkerPool
         end
         @work_items.shift unless self.shutdown?
       end
-      @on_pop_callbacks.each(&:call)
+      @on_pop_callbacks.each{ |p| p.call(self, work_item) } if !work_item.nil?
       work_item
     end
 


### PR DESCRIPTION
This updates the `DefaultQueue` callbacks to pass the queue and
work item to them. This makes them consistent with the worker
callbacks and makes them more useful. Now they can use the queue
or work item if needed.

This also fixes a bug with running the on pop callbacks even if
they popped a `nil` work item. Dat worker pool as a whole ignores
`nil` work items and this makes the on pop consistent with that
behavior. The bug this fixes is running on pop callbacks when a
queue is shutdown with a worker thread waiting on pop. Prevously
the worker thread would get a `nil` work item but it would have
caused the on pop callbacks to run.

@kellyredding - Ready for review.