### PR TITLE
Rename `Worker` to `DefaultWorker`, setup for worker mixin

### DIFF
--- a/lib/dat-worker-pool.rb
+++ b/lib/dat-worker-pool.rb
@@ -3,8 +3,8 @@ require 'system_timer'
 require 'thread'
 
 require 'dat-worker-pool/version'
+require 'dat-worker-pool/default_worker'
 require 'dat-worker-pool/queue'
-require 'dat-worker-pool/worker'
 
 class DatWorkerPool
 
@@ -128,7 +128,7 @@ class DatWorkerPool
   end
 
   def spawn_worker!
-    Worker.new(@queue).tap do |w|
+    DefaultWorker.new(@queue).tap do |w|
       w.on_work = proc{ |worker, work_item| do_work(work_item) }
 
       w.on_error_callbacks    = @on_worker_error_callbacks

--- a/lib/dat-worker-pool/default_worker.rb
+++ b/lib/dat-worker-pool/default_worker.rb
@@ -3,7 +3,7 @@ require 'dat-worker-pool'
 
 class DatWorkerPool
 
-  class Worker
+  class DefaultWorker
 
     attr_accessor :on_work, :on_error_callbacks
     attr_accessor :on_start_callbacks, :on_shutdown_callbacks

--- a/test/unit/dat-worker-pool_tests.rb
+++ b/test/unit/dat-worker-pool_tests.rb
@@ -237,7 +237,7 @@ class DatWorkerPool
         ForceShutdownSpyWorker.new(@worker_pool.queue)
       end
       stub_workers = @workers.dup
-      Assert.stub(Worker, :new){ stub_workers.pop }
+      Assert.stub(DefaultWorker, :new){ stub_workers.pop }
 
       @worker_pool.start
     end
@@ -259,7 +259,7 @@ class DatWorkerPool
       @workers = @num_workers.times.map do
         ForceShutdownJoinErrorWorker.new(@worker_pool.queue)
       end
-      Assert.stub(Worker, :new){ @workers.pop }
+      Assert.stub(DefaultWorker, :new){ @workers.pop }
 
       @worker_pool.start
     end
@@ -301,7 +301,7 @@ class DatWorkerPool
     end
   end
 
-  class ForceShutdownSpyWorker < Worker
+  class ForceShutdownSpyWorker < DefaultWorker
     attr_reader :raised_error, :joined
 
     def start; end

--- a/test/unit/default_worker_tests.rb
+++ b/test/unit/default_worker_tests.rb
@@ -1,17 +1,17 @@
 require 'assert'
-require 'dat-worker-pool/worker'
+require 'dat-worker-pool/default_worker'
 
 require 'dat-worker-pool'
 require 'dat-worker-pool/default_queue'
 
-class DatWorkerPool::Worker
+class DatWorkerPool::DefaultWorker
 
   class UnitTests < Assert::Context
-    desc "DatWorkerPool::Worker"
+    desc "DatWorkerPool::DefaultWorker"
     setup do
       @queue = DatWorkerPool::DefaultQueue.new.tap(&:start)
       @work_done = []
-      @worker = DatWorkerPool::Worker.new(@queue).tap do |w|
+      @worker = DatWorkerPool::DefaultWorker.new(@queue).tap do |w|
         w.on_work = proc{ |worker, work| @work_done << work }
       end
     end
@@ -29,7 +29,7 @@ class DatWorkerPool::Worker
     should have_imeths :start, :shutdown, :join, :raise, :running?
 
     should "default its callbacks" do
-      worker = DatWorkerPool::Worker.new(@queue)
+      worker = DatWorkerPool::DefaultWorker.new(@queue)
       assert_equal [], worker.on_error_callbacks
       assert_equal [], worker.on_start_callbacks
       assert_equal [], worker.on_shutdown_callbacks
@@ -106,7 +106,7 @@ class DatWorkerPool::Worker
       @before_work_called_at   = nil
       @after_work_called_with  = nil
       @after_work_called_at    = nil
-      @worker = DatWorkerPool::Worker.new(@queue).tap do |w|
+      @worker = DatWorkerPool::DefaultWorker.new(@queue).tap do |w|
         w.on_error_callbacks << proc do |*args|
           @on_error_called_with = args
         end


### PR DESCRIPTION
This renames the `Worker` class to `DefaultWorker`. This is setup
for having a `Worker` mixin for defining custom worker classes for
dat worker pool. This renames the existing worker as a first step
so the `Worker` name is now available.

@kellyredding - Ready for review.