### PR TITLE
Add `Runner` class and `Worker` mixin

### DIFF
--- a/lib/dat-worker-pool/runner.rb
+++ b/lib/dat-worker-pool/runner.rb
@@ -1,0 +1,125 @@
+require 'system_timer'
+require 'thread'
+require 'dat-worker-pool'
+
+class DatWorkerPool
+
+  class Runner
+
+    attr_reader :num_workers, :worker_class, :workers
+    attr_reader :queue
+
+    # TODO - remove "do work proc" once pool is passed a worker class
+    def initialize(args)
+      @num_workers  = args[:num_workers]
+      @queue        = args[:queue]
+      @worker_class = args[:worker_class]
+      @do_work_proc = args[:do_work_proc]
+
+      @mutex   = Mutex.new
+      @workers = []
+
+      @workers_waiting = WorkersWaiting.new
+    end
+
+    def start
+      @queue.start
+      @num_workers.times{ spawn_worker }
+    end
+
+    # the workers should be told to shutdown before the queue because the queue
+    # shutdown will wake them up; a worker popping on a shutdown queue will
+    # always get `nil` back and will loop as fast as allowed until its shutdown
+    # flag is flipped, so shutting down the workers then the queue keeps them from
+    # looping as fast as possible; use an until loop instead of each to join all
+    # the workers, while we are joining a worker a different worker can shutdown
+    # and remove itself from the `@workers` array
+    def shutdown(timeout = nil)
+      begin
+        OptionalTimeout.new(timeout) do
+          @workers.each(&:shutdown)
+          @queue.shutdown
+          @workers.first.join until @workers.empty?
+        end
+      rescue TimeoutError
+        force_shutdown(timeout, caller)
+      end
+    end
+
+    def workers_waiting_count
+      @workers_waiting.count
+    end
+
+    def increment_worker_waiting
+      @workers_waiting.increment
+    end
+
+    def decrement_worker_waiting
+      @workers_waiting.decrement
+    end
+
+    def despawn_worker(worker)
+      @mutex.synchronize{ @workers.delete(worker) }
+    end
+
+    private
+
+    def spawn_worker
+      @mutex.synchronize do
+        @worker_class.new(self, @queue).tap do |w|
+          # TODO - remove once a custom worker class can be passed to pool
+          w.on_work = @do_work_proc
+          @workers << w
+          w.start
+        end
+      end
+    end
+
+    # use an until loop instead of each to join all the workers, while we are
+    # joining a worker a different worker can shutdown and remove itself from
+    # the `@workers` array; `rescue false` when joining the workers, ruby will
+    # raise any exceptions that aren't handled by a thread when its joined, this
+    # ensures if the hard shutdown is raised and not rescued (for example, in
+    # the workers ensure), then it won't cause the forced shutdown to end
+    # prematurely
+    def force_shutdown(timeout, backtrace)
+      error = ShutdownError.new("Timed out shutting down (#{timeout} seconds).")
+      error.set_backtrace(backtrace)
+      until @workers.empty?
+        worker = @workers.first
+        worker.raise(error)
+        worker.join rescue false
+        @workers.delete(worker)
+      end
+    end
+
+    module OptionalTimeout
+      def self.new(seconds, &block)
+        if seconds
+          SystemTimer.timeout(seconds, TimeoutError, &block)
+        else
+          block.call
+        end
+      end
+    end
+
+    class WorkersWaiting
+      attr_reader :count
+
+      def initialize
+        @mutex = Mutex.new
+        @count = 0
+      end
+
+      def increment
+        @mutex.synchronize{ @count += 1 }
+      end
+
+      def decrement
+        @mutex.synchronize{ @count -= 1 }
+      end
+    end
+
+  end
+
+end

--- a/lib/dat-worker-pool/worker.rb
+++ b/lib/dat-worker-pool/worker.rb
@@ -1,0 +1,56 @@
+require 'thread'
+
+class DatWorkerPool
+
+  module Worker
+
+    def self.included(klass)
+      klass.class_eval do
+        extend ClassMethods
+        include InstanceMethods
+      end
+    end
+
+    module ClassMethods
+
+      def on_start_callbacks;    @on_start_callbacks    ||= []; end
+      def on_shutdown_callbacks; @on_shutdown_callbacks ||= []; end
+      def on_sleep_callbacks;    @on_sleep_callbacks    ||= []; end
+      def on_wakeup_callbacks;   @on_wakeup_callbacks   ||= []; end
+      def on_error_callbacks;    @on_error_callbacks    ||= []; end
+      def before_work_callbacks; @before_work_callbacks ||= []; end
+      def after_work_callbacks;  @after_work_callbacks  ||= []; end
+
+      def on_start(&block);    self.on_start_callbacks    << block; end
+      def on_shutdown(&block); self.on_shutdown_callbacks << block; end
+      def on_sleep(&block);    self.on_sleep_callbacks    << block; end
+      def on_wakeup(&block);   self.on_wakeup_callbacks   << block; end
+      def on_error(&block);    self.on_error_callbacks    << block; end
+      def before_work(&block); self.before_work_callbacks << block; end
+      def after_work(&block);  self.after_work_callbacks  << block; end
+
+      def prepend_on_start(&block);    self.on_start_callbacks.unshift(block);    end
+      def prepend_on_shutdown(&block); self.on_shutdown_callbacks.unshift(block); end
+      def prepend_on_sleep(&block);    self.on_sleep_callbacks.unshift(block);    end
+      def prepend_on_wakeup(&block);   self.on_wakeup_callbacks.unshift(block);   end
+      def prepend_on_error(&block);    self.on_error_callbacks.unshift(block);    end
+      def prepend_before_work(&block); self.before_work_callbacks.unshift(block); end
+      def prepend_after_work(&block);  self.after_work_callbacks.unshift(block);  end
+
+    end
+
+    module InstanceMethods
+
+      private
+
+      def run_callback(callback, *args)
+        (self.class.send("#{callback}_callbacks") || []).each do |callback|
+          callback.call(self, *args)
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/test/support/thread_spies.rb
+++ b/test/support/thread_spies.rb
@@ -1,7 +1,7 @@
 require 'thread'
 
 class MutexSpy < Mutex
-  attr_reader :synchronize_called
+  attr_accessor :synchronize_called
 
   def initialize
     @synchronize_called = false

--- a/test/unit/default_worker_tests.rb
+++ b/test/unit/default_worker_tests.rb
@@ -3,41 +3,49 @@ require 'dat-worker-pool/default_worker'
 
 require 'dat-worker-pool'
 require 'dat-worker-pool/default_queue'
+require 'dat-worker-pool/runner'
+require 'dat-worker-pool/worker'
 
 class DatWorkerPool::DefaultWorker
 
   class UnitTests < Assert::Context
     desc "DatWorkerPool::DefaultWorker"
     setup do
-      @queue = DatWorkerPool::DefaultQueue.new.tap(&:start)
-      @work_done = []
-      @worker = DatWorkerPool::DefaultWorker.new(@queue).tap do |w|
-        w.on_work = proc{ |worker, work| @work_done << work }
-      end
+      @worker_class = DatWorkerPool::DefaultWorker
+    end
+    subject{ @worker_class }
+
+    should "be a dat worker pool worker" do
+      assert_includes DatWorkerPool::Worker, subject
+    end
+
+  end
+
+  class InitSetupTests < UnitTests
+    desc "when init"
+    setup do
+      @queue  = DatWorkerPool::DefaultQueue.new.tap(&:start)
+      @runner = DatWorkerPool::Runner.new(:queue => @queue)
     end
     teardown do
-      @worker.shutdown
+      @worker.shutdown if @worker
       @queue.shutdown
-      @worker.join
+      @worker.join if @worker
     end
     subject{ @worker }
 
-    should have_accessors :on_work, :on_error_callbacks
-    should have_accessors :on_start_callbacks, :on_shutdown_callbacks
-    should have_accessors :on_sleep_callbacks, :on_wakeup_callbacks
-    should have_accessors :before_work_callbacks, :after_work_callbacks
-    should have_imeths :start, :shutdown, :join, :raise, :running?
+  end
 
-    should "default its callbacks" do
-      worker = DatWorkerPool::DefaultWorker.new(@queue)
-      assert_equal [], worker.on_error_callbacks
-      assert_equal [], worker.on_start_callbacks
-      assert_equal [], worker.on_shutdown_callbacks
-      assert_equal [], worker.on_sleep_callbacks
-      assert_equal [], worker.on_wakeup_callbacks
-      assert_equal [], worker.before_work_callbacks
-      assert_equal [], worker.after_work_callbacks
+  class InitTests < InitSetupTests
+    setup do
+      @work_done = []
+      @worker = @worker_class.new(@runner, @queue).tap do |w|
+        w.on_work = proc{ |work| @work_done << work }
+      end
     end
+
+    should have_accessors :on_work
+    should have_imeths :start, :shutdown, :join, :raise, :running?
 
     should "start a thread with it's work loop using `start`" do
       thread = nil
@@ -56,6 +64,19 @@ class DatWorkerPool::DefaultWorker
       assert_equal [ 'one', 'two' ], @work_done
     end
 
+    should "increment and decrement its runners workers waiting count" do
+      increment_call_count = 0
+      Assert.stub(@runner, :increment_worker_waiting){ increment_call_count += 1 }
+      decrement_call_count = 0
+      Assert.stub(@runner, :decrement_worker_waiting){ decrement_call_count += 1 }
+
+      subject.start
+      @queue.push Factory.string
+
+      assert_equal 2, increment_call_count
+      assert_equal 1, decrement_call_count
+    end
+
     should "flag itself for exiting it's work loop using `shutdown` and " \
            "end it's thread once it's queue is shutdown" do
       thread = subject.start
@@ -69,8 +90,20 @@ class DatWorkerPool::DefaultWorker
       assert_not subject.running?
     end
 
+    should "despawn itself from its runner when shutdown" do
+      despawned_worker = nil
+      Assert.stub(@runner, :despawn_worker){ |worker| despawned_worker = worker }
+
+      subject.start
+      subject.join 0.1 # trigger the worker's thread to run
+      assert_nothing_raised{ subject.shutdown }
+      @queue.shutdown
+
+      assert_same subject, despawned_worker
+    end
+
     should "raise an error on the thread using `raise`" do
-      subject.on_work = proc do |worker, work|
+      subject.on_work = proc do |work|
         begin
           sleep 1
         rescue RuntimeError => error
@@ -89,53 +122,58 @@ class DatWorkerPool::DefaultWorker
 
   end
 
-  class CallbacksTests < UnitTests
-    desc "callbacks"
+  class CallbacksTests < InitSetupTests
     setup do
       @call_counter = 0
-      @on_error_called_with    = nil
-      @on_start_called_with    = nil
-      @on_start_called_at      = nil
+
+      @on_start_called_with = nil
+      @on_start_called_at   = nil
+      @worker_class.on_start do |*args|
+        @on_start_called_with = args
+        @on_start_called_at   = (@call_counter += 1)
+      end
+
       @on_shutdown_called_with = nil
       @on_shutdown_called_at   = nil
-      @on_sleep_called_with    = nil
-      @on_sleep_called_at      = nil
-      @on_wakeup_called_with   = nil
-      @on_wakeup_called_at     = nil
+      @worker_class.on_shutdown do |*args|
+        @on_shutdown_called_with = args
+        @on_shutdown_called_at   = (@call_counter += 1)
+      end
+
+      @on_sleep_called_with = nil
+      @on_sleep_called_at   = nil
+      @worker_class.on_sleep do |*args|
+        @on_sleep_called_with = args
+        @on_sleep_called_at   = (@call_counter += 1)
+      end
+
+      @on_wakeup_called_with = nil
+      @on_wakeup_called_at   = nil
+      @worker_class.on_wakeup do |*args|
+        @on_wakeup_called_with = args
+        @on_wakeup_called_at   = (@call_counter += 1)
+      end
+
+      @on_error_called_with = nil
+      @worker_class.on_error{ |*args| @on_error_called_with = args }
+
       @before_work_called_with = nil
       @before_work_called_at   = nil
+      @worker_class.before_work do |*args|
+        @before_work_called_with = args
+        @before_work_called_at   = (@call_counter += 1)
+      end
+
       @after_work_called_with  = nil
       @after_work_called_at    = nil
-      @worker = DatWorkerPool::DefaultWorker.new(@queue).tap do |w|
-        w.on_error_callbacks << proc do |*args|
-          @on_error_called_with = args
-        end
-        w.on_start_callbacks << proc do |*args|
-          @on_start_called_with = args
-          @on_start_called_at   = (@call_counter += 1)
-        end
-        w.on_shutdown_callbacks << proc do |*args|
-          @on_shutdown_called_with = args
-          @on_shutdown_called_at   = (@call_counter += 1)
-        end
-        w.on_sleep_callbacks << proc do |*args|
-          @on_sleep_called_with = args
-          @on_sleep_called_at   = (@call_counter += 1)
-        end
-        w.on_wakeup_callbacks << proc do |*args|
-          @on_wakeup_called_with = args
-          @on_wakeup_called_at   = (@call_counter += 1)
-        end
-        w.before_work_callbacks << proc do |*args|
-          @before_work_called_with = args
-          @before_work_called_at   = (@call_counter += 1)
-        end
-        w.after_work_callbacks << proc do |*args|
-          @after_work_called_with = args
-          @after_work_called_at   = (@call_counter += 1)
-        end
+      @worker_class.after_work do |*args|
+        @after_work_called_with = args
+        @after_work_called_at   = (@call_counter += 1)
       end
+
+      @worker = @worker_class.new(@runner, @queue)
     end
+    subject{ @worker }
 
     should "pass its self to its start, shutdown, sleep and wakeup callbacks" do
       subject.start

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -1,0 +1,260 @@
+require 'assert'
+require 'dat-worker-pool/runner'
+
+require 'dat-worker-pool/default_queue'
+require 'dat-worker-pool/default_worker'
+require 'test/support/thread_spies'
+
+class DatWorkerPool::Runner
+
+  class UnitTests < Assert::Context
+    desc "DatWorkerPool::Runner"
+    setup do
+      @runner_class = DatWorkerPool::Runner
+    end
+    subject{ @runner_class }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @num_workers  = Factory.integer(4)
+      @queue        = DatWorkerPool::DefaultQueue.new
+      @worker_class = WorkerSpy
+      @do_work_proc = proc{ Factory.string }
+
+      @mutex_spy = MutexSpy.new
+      Assert.stub(Mutex, :new){ @mutex_spy }
+
+      @options = {
+        :num_workers  => @num_workers,
+        :queue        => @queue,
+        :worker_class => @worker_class,
+        :do_work_proc => @do_work_proc
+      }
+      @runner = @runner_class.new(@options)
+    end
+    subject{ @runner }
+
+    should have_readers :num_workers, :worker_class, :workers
+    should have_readers :queue
+    should have_imeths :start, :shutdown
+    should have_imeths :workers_waiting_count
+    should have_imeths :increment_worker_waiting, :decrement_worker_waiting
+    should have_imeths :despawn_worker
+
+    should "know its attributes" do
+      assert_equal @num_workers,  subject.num_workers
+      assert_equal @worker_class, subject.worker_class
+      assert_equal @queue,        subject.queue
+    end
+
+    should "default its workers to an empty array" do
+      assert_equal [], subject.workers
+    end
+
+    should "demeter its workers waiting" do
+      assert_equal 0, subject.workers_waiting_count
+      subject.increment_worker_waiting
+      assert_equal 1, subject.workers_waiting_count
+      subject.decrement_worker_waiting
+      assert_equal 0, subject.workers_waiting_count
+    end
+
+    should "start its queue when its started" do
+      assert_false @queue.running?
+      subject.start
+      assert_true @queue.running?
+    end
+
+    should "spawn workers when its started" do
+      subject.start
+      assert_equal @num_workers, subject.workers.size
+      subject.workers.each do |worker|
+        assert_instance_of @worker_class, worker
+        assert_equal subject,       worker.runner
+        assert_equal @queue,        worker.queue
+        assert_equal @do_work_proc, worker.on_work
+        assert_true worker.start_called
+      end
+    end
+
+    should "lock access to its workers when started" do
+      assert_false @mutex_spy.synchronize_called
+      subject.start
+      assert_true @mutex_spy.synchronize_called
+    end
+
+  end
+
+  class StartedTests < InitTests
+    desc "and started"
+    setup do
+      @runner.start
+      @mutex_spy.synchronize_called = false # reset so we can test it below
+    end
+
+    should "remove a worker from its workers using `despawn_worker`" do
+      worker = subject.workers.choice
+
+      assert_false @mutex_spy.synchronize_called
+      subject.despawn_worker(worker)
+      assert_true @mutex_spy.synchronize_called
+      assert_not_includes worker, subject.workers
+    end
+
+  end
+
+  class ShutdownSetupTests < InitTests
+    desc "and started and shutdown"
+
+  end
+
+  class ShutdownTests < ShutdownSetupTests
+    setup do
+      @timeout_seconds         = nil
+      @optional_timeout_called = false
+      # this acts as a spy but also keeps the shutdown from ever timing out
+      Assert.stub(OptionalTimeout, :new) do |secs, &block|
+        @timeout_seconds         = secs
+        @optional_timeout_called = true
+        block.call
+      end
+
+      @runner.start
+    end
+
+    should "optionally timeout when shutdown" do
+      subject.shutdown
+      assert_nil @timeout_seconds
+      assert_true @optional_timeout_called
+
+      @optional_timeout_called = false
+      seconds = Factory.integer
+      subject.shutdown(seconds)
+      assert_equal seconds, @timeout_seconds
+      assert_true @optional_timeout_called
+    end
+
+    should "shutdown all of its workers" do
+      subject.workers.each do |worker|
+        assert_false worker.shutdown_called
+      end
+      subject.shutdown(Factory.boolean ? Factory.integer : nil)
+      subject.workers.each do |worker|
+        assert_true worker.shutdown_called
+      end
+    end
+
+    should "shutdown its queue" do
+      assert_false @queue.shutdown?
+      subject.shutdown(Factory.boolean ? Factory.integer : nil)
+      assert_true @queue.shutdown?
+    end
+
+    should "join its workers waiting for them to finish" do
+      subject.workers.each do |worker|
+        assert_false worker.join_called
+      end
+      subject.shutdown(Factory.boolean ? Factory.integer : nil)
+      subject.workers.each do |worker|
+        assert_true worker.join_called
+      end
+    end
+
+  end
+
+  class ForceShutdownSetupTests < ShutdownSetupTests
+    desc "which times out and is forced to shutdown"
+    setup do
+      # this makes the runner force shutdown, by raising timeout error we
+      # are saying the graceful shutdown timed out
+      Assert.stub(OptionalTimeout, :new){ raise DatWorkerPool::TimeoutError }
+    end
+
+  end
+
+  class ForcedShutdownTests < ForceShutdownSetupTests
+    setup do
+      @options[:worker_class] = ForceShutdownSpyWorker
+      @runner = @runner_class.new(@options)
+      @runner.start
+
+      @workers = @runner.workers.dup
+    end
+
+    should "force workers to shutdown by raising an error in their thread" do
+      subject.shutdown(Factory.integer)
+
+      @workers.each do |worker|
+        assert_instance_of DatWorkerPool::ShutdownError, worker.raised_error
+        assert_true worker.join_called
+      end
+    end
+
+  end
+
+  class ForcedShutdownWithErrorsWhileJoiningTests < ForceShutdownSetupTests
+    desc "forced shutdown with errors while joining worker threads"
+    setup do
+      @options[:worker_class] = ForceShutdownJoinErrorWorker
+      @runner = @runner_class.new(@options)
+      @runner.start
+    end
+
+    should "not raise any errors and continue shutting down" do
+      # if this is broken its possible it can create an infinite loop, so we
+      # time it out and let it throw an exception
+      SystemTimer.timeout(1) do
+        assert_nothing_raised{ subject.shutdown(Factory.integer) }
+      end
+    end
+
+  end
+
+  class WorkerSpy < DatWorkerPool::DefaultWorker
+    attr_reader :runner, :queue
+    attr_reader :start_called, :shutdown_called
+    attr_reader :join_called
+
+    def initialize(*args)
+      super
+
+      @start_called    = false
+      @shutdown_called = false
+      @join_called     = false
+    end
+
+    # TODO - switch to running flag once its not thread dependent (like queue)
+    def start
+      @start_called = true
+      super
+    end
+
+    def shutdown
+      @shutdown_called = true
+      super
+    end
+
+    def join(*args); @join_called = true; end
+  end
+
+  class ForceShutdownSpyWorker < WorkerSpy
+    attr_reader :raised_error
+
+    def start; end
+    def raise(error); @raised_error = error; end
+  end
+
+  # this creates a rare scenario where as we are joining a worker, it throws
+  # an error; this can happen when force shutting down a worker; we raise an
+  # error in the worker thread to force it to shut down, the error can be raised
+  # at any point in the worker thread, including its ensure block in its
+  # `work_loop`, if this happens, we will get the error raised when we `join`
+  # the worker thread
+  class ForceShutdownJoinErrorWorker < ForceShutdownSpyWorker
+    def join; raise Factory.exception; end
+  end
+
+end

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -1,0 +1,110 @@
+require 'assert'
+require 'dat-worker-pool/worker'
+
+module DatWorkerPool::Worker
+
+  class UnitTests < Assert::Context
+    desc "DatWorkerPool::Worker"
+    setup do
+      @worker_class = Class.new do
+        include DatWorkerPool::Worker
+      end
+    end
+    subject{ @worker_class }
+
+    should have_imeths :on_start_callbacks, :on_shutdown_callbacks
+    should have_imeths :on_sleep_callbacks, :on_wakeup_callbacks
+    should have_imeths :on_error_callbacks
+    should have_imeths :before_work_callbacks, :after_work_callbacks
+    should have_imeths :on_start, :on_shutdown
+    should have_imeths :on_sleep, :on_wakeup
+    should have_imeths :on_error
+    should have_imeths :before_work, :after_work
+    should have_imeths :prepend_on_start, :prepend_on_shutdown
+    should have_imeths :prepend_on_sleep, :prepend_on_wakeup
+    should have_imeths :prepend_on_error
+    should have_imeths :prepend_before_work, :prepend_after_work
+
+    should "not have any callbacks by default" do
+      assert_equal [], subject.on_start_callbacks
+      assert_equal [], subject.on_shutdown_callbacks
+      assert_equal [], subject.on_sleep_callbacks
+      assert_equal [], subject.on_wakeup_callbacks
+      assert_equal [], subject.on_error_callbacks
+      assert_equal [], subject.before_work_callbacks
+      assert_equal [], subject.after_work_callbacks
+    end
+
+    should "allow appending callbacks" do
+      callback = proc{ Factory.string }
+      # add a callback to each type to show we are appending
+      subject.on_start_callbacks    << proc{ Factory.string }
+      subject.on_shutdown_callbacks << proc{ Factory.string }
+      subject.on_sleep_callbacks    << proc{ Factory.string }
+      subject.on_wakeup_callbacks   << proc{ Factory.string }
+      subject.on_error_callbacks    << proc{ Factory.string }
+      subject.before_work_callbacks << proc{ Factory.string }
+      subject.after_work_callbacks  << proc{ Factory.string }
+
+      subject.on_start(&callback)
+      assert_equal callback, subject.on_start_callbacks.last
+
+      subject.on_shutdown(&callback)
+      assert_equal callback, subject.on_shutdown_callbacks.last
+
+      subject.on_sleep(&callback)
+      assert_equal callback, subject.on_sleep_callbacks.last
+
+      subject.on_wakeup(&callback)
+      assert_equal callback, subject.on_wakeup_callbacks.last
+
+      subject.on_error(&callback)
+      assert_equal callback, subject.on_error_callbacks.last
+
+      subject.before_work(&callback)
+      assert_equal callback, subject.before_work_callbacks.last
+
+      subject.after_work(&callback)
+      assert_equal callback, subject.after_work_callbacks.last
+    end
+
+    should "allow prepending callbacks" do
+      callback = proc{ Factory.string }
+      # add a callback to each type to show we are appending
+      subject.on_start_callbacks    << proc{ Factory.string }
+      subject.on_shutdown_callbacks << proc{ Factory.string }
+      subject.on_sleep_callbacks    << proc{ Factory.string }
+      subject.on_wakeup_callbacks   << proc{ Factory.string }
+      subject.on_error_callbacks    << proc{ Factory.string }
+      subject.before_work_callbacks << proc{ Factory.string }
+      subject.after_work_callbacks  << proc{ Factory.string }
+
+      subject.prepend_on_start(&callback)
+      assert_equal callback, subject.on_start_callbacks.first
+
+      subject.prepend_on_shutdown(&callback)
+      assert_equal callback, subject.on_shutdown_callbacks.first
+
+      subject.prepend_on_sleep(&callback)
+      assert_equal callback, subject.on_sleep_callbacks.first
+
+      subject.prepend_on_wakeup(&callback)
+      assert_equal callback, subject.on_wakeup_callbacks.first
+
+      subject.prepend_on_error(&callback)
+      assert_equal callback, subject.on_error_callbacks.first
+
+      subject.prepend_before_work(&callback)
+      assert_equal callback, subject.before_work_callbacks.first
+
+      subject.prepend_after_work(&callback)
+      assert_equal callback, subject.after_work_callbacks.first
+    end
+
+  end
+
+  class InitTests < UnitTests
+
+  end
+
+end


### PR DESCRIPTION
This adds a `Runner` class and `Worker` mixin. This is part of an 
effort to allow providing a custom worker class and in general make 
dat worker pool more flexible and powerful.

This adds a `Runner` which is built by a worker pool and passed
to a worker. This is so we can remove the default worker callbacks
that the worker pool added to its workers for despawning workers
and incrementing/decrementing waiting worker counts. Instead of
using the callbacks and relying on ruby's closures to allow
calling private methods on the worker pool, the worker now
directly calls the runner. When the worker sleeps/wakes up it
calls a public increment/decrement method on the runner. When
it shuts down it calls the public despawn worker method on the
runner. The runner allows methods that are intended to be private
and internal to the working of the worker pool to be public so
the worker can call them.

As part of adding a runner, the start and shutdown logic was
moved into the runner. This allows the runner to control the
order the queue and workers are started the same way the worker
pool used to. Otherwise, the runner has to provide extra methods
for shutting down the workers and waiting on them to finish so
the worker pool can control the order.

This also adds a `Worker` mixin that will eventually be the base
mixin that dat worker pool provides for defining custom workers.
For now, this moves the callbacks logic into it as class DSL
methods. This is a friendlier interface than the previous instance
methods. This also mixes in the `Worker` mixin into the default
worker.

As part of changing the callbacks, this updates how a worker pool
proxies the callback methods. The callbacks are stored on the class
not the instance of the default worker. The dat worker pool
callback methods functionally work the same but they access its
worker class DSL methods. This will be removed once a worker class
can be passed to a worker pool as using the worker class DSL is
the preferred method to add callbacks.

@kellyredding - Ready for review.