### PR TITLE
Add the rest of the `Worker` logic from `DefaultWorker`

### DIFF
--- a/lib/dat-worker-pool/default_worker.rb
+++ b/lib/dat-worker-pool/default_worker.rb
@@ -9,79 +9,13 @@ class DatWorkerPool
 
     attr_accessor :on_work
 
-    def initialize(runner, queue)
-      @runner  = runner
-      @queue   = queue
+    def initialize(*args)
+      super
       @on_work = proc{ |work_item| }
-
-      @shutdown = false
-      @thread   = nil
     end
 
-    def start
-      @thread ||= Thread.new{ work_loop }
-    end
-
-    def shutdown
-      @shutdown = true
-    end
-
-    def running?
-      !!(@thread && @thread.alive?)
-    end
-
-    def join(*args)
-      @thread.join(*args) if running?
-    end
-
-    def raise(*args)
-      @thread.raise(*args) if running?
-    end
-
-    private
-
-    # * Rescue `ShutdownError` but don't do anything with it. We want to handle
-    #   the error but we just want it to cause the worker to exit its work loop.
-    #   If the `ShutdownError` isn't rescued, it will be raised when the worker
-    #   is joined.
-    def work_loop
-      run_callback 'on_start'
-      loop do
-        break if @shutdown
-        fetch_and_do_work
-      end
-    rescue ShutdownError
-    ensure
-      run_callback 'on_shutdown'
-      @runner.despawn_worker(self)
-      @thread = nil
-    end
-
-    # * Rescue `ShutdownError` but re-raise it after calling the error
-    #   callbacks. This ensures it causes the work loop to exit (see
-    #   `work_loop`).
-    def fetch_and_do_work
-      @runner.increment_worker_waiting
-      run_callback 'on_sleep'
-      work_item = @queue.pop
-      run_callback 'on_wakeup'
-      @runner.decrement_worker_waiting
-      do_work(work_item) if work_item
-    rescue ShutdownError => exception
-      handle_exception(exception, work_item)
-      raise exception
-    rescue StandardError => exception
-      handle_exception(exception, work_item)
-    end
-
-    def do_work(work_item)
-      run_callback 'before_work', work_item
+    def work!(work_item)
       @on_work.call(work_item)
-      run_callback 'after_work', work_item
-    end
-
-    def handle_exception(exception, work_item = nil)
-      run_callback 'on_error', exception, work_item
     end
 
   end

--- a/lib/dat-worker-pool/worker.rb
+++ b/lib/dat-worker-pool/worker.rb
@@ -41,7 +41,93 @@ class DatWorkerPool
 
     module InstanceMethods
 
+      def initialize(runner, queue)
+        @runner  = runner
+        @queue   = queue
+        @running = false
+        @thread  = nil
+      end
+
+      def work(work_item)
+        run_callback('before_work', work_item)
+        work!(work_item)
+        run_callback('after_work', work_item)
+      end
+
+      def start
+        @running = true
+        @thread ||= Thread.new{ work_loop }
+      end
+
+      def shutdown
+        @running = false
+      end
+
+      def running?
+        !!@running
+      end
+
+      def shutdown?
+        !self.running?
+      end
+
+      # this is needed because even if the running flag has been set to false
+      # (meaning the worker has been shutdown) the thread may still be alive
+      # because its `work` is taking a long time or its still trying to shut
+      # down
+      def thread_alive?
+        !!(@thread && @thread.alive?)
+      end
+
+      def join(*args)
+        @thread.join(*args) if self.thread_alive?
+      end
+
+      def raise(*args)
+        @thread.raise(*args) if self.thread_alive?
+      end
+
       private
+
+      # overwrite this method to add custom work logic; this has to be
+      # overwritten or the workers will not know how to handle a work item
+      def work!(work_item)
+        raise NotImplementedError
+      end
+
+      # rescue `ShutdownError` and ignore it, its already been passed to the
+      # on-error callbacks in `fetch_and_work`; the shutdown error is just used
+      # to force the worker to exit its infinite loop if the worker pool is
+      # forcing itself to shutdown
+      def work_loop
+        run_callback 'on_start'
+        fetch_and_work while self.running?
+      rescue ShutdownError
+      ensure
+        run_callback 'on_shutdown'
+        @runner.despawn_worker(self)
+        @thread = nil
+      end
+
+      # rescue `ShutdownError` but re-raise it after calling the on-error
+      # callbacks, this ensures it causes the loop in `work_loop` to exit
+      def fetch_and_work
+        @runner.increment_worker_waiting
+        run_callback 'on_sleep'
+        work_item = @queue.pop
+        run_callback 'on_wakeup'
+        @runner.decrement_worker_waiting
+        work(work_item) if work_item
+      rescue ShutdownError => exception
+        handle_exception(exception, work_item)
+        Thread.current.raise exception
+      rescue StandardError => exception
+        handle_exception(exception, work_item)
+      end
+
+      def handle_exception(exception, work_item = nil)
+        run_callback('on_error', exception, work_item)
+      end
 
       def run_callback(callback, *args)
         (self.class.send("#{callback}_callbacks") || []).each do |callback|

--- a/test/unit/default_worker_tests.rb
+++ b/test/unit/default_worker_tests.rb
@@ -21,215 +21,32 @@ class DatWorkerPool::DefaultWorker
 
   end
 
-  class InitSetupTests < UnitTests
-    desc "when init"
+  class InitTests < UnitTests
     setup do
       @queue  = DatWorkerPool::DefaultQueue.new.tap(&:start)
       @runner = DatWorkerPool::Runner.new(:queue => @queue)
-    end
-    teardown do
-      @worker.shutdown if @worker
-      @queue.shutdown
-      @worker.join if @worker
-    end
-    subject{ @worker }
 
-  end
-
-  class InitTests < InitSetupTests
-    setup do
       @work_done = []
-      @worker = @worker_class.new(@runner, @queue).tap do |w|
-        w.on_work = proc{ |work| @work_done << work }
-      end
-    end
-
-    should have_accessors :on_work
-    should have_imeths :start, :shutdown, :join, :raise, :running?
-
-    should "start a thread with it's work loop using `start`" do
-      thread = nil
-      assert_nothing_raised{ thread = subject.start }
-      assert_instance_of Thread, thread
-      assert thread.alive?
-      assert subject.running?
-    end
-
-    should "call the block it's passed when it get's work from the queue" do
-      subject.start
-      @queue.push 'one'
-      subject.join 0.1 # trigger the worker's thread to run
-      @queue.push 'two'
-      subject.join 0.1 # trigger the worker's thread to run
-      assert_equal [ 'one', 'two' ], @work_done
-    end
-
-    should "increment and decrement its runners workers waiting count" do
-      increment_call_count = 0
-      Assert.stub(@runner, :increment_worker_waiting){ increment_call_count += 1 }
-      decrement_call_count = 0
-      Assert.stub(@runner, :decrement_worker_waiting){ decrement_call_count += 1 }
-
-      subject.start
-      @queue.push Factory.string
-
-      assert_equal 2, increment_call_count
-      assert_equal 1, decrement_call_count
-    end
-
-    should "flag itself for exiting it's work loop using `shutdown` and " \
-           "end it's thread once it's queue is shutdown" do
-      thread = subject.start
-      subject.join 0.1 # trigger the worker's thread to run, allow it to get into it's
-                       # work loop
-      assert_nothing_raised{ subject.shutdown }
-      @queue.shutdown
-
-      subject.join 0.1 # trigger the worker's thread to run, should exit
-      assert_not thread.alive?
-      assert_not subject.running?
-    end
-
-    should "despawn itself from its runner when shutdown" do
-      despawned_worker = nil
-      Assert.stub(@runner, :despawn_worker){ |worker| despawned_worker = worker }
-
-      subject.start
-      subject.join 0.1 # trigger the worker's thread to run
-      assert_nothing_raised{ subject.shutdown }
-      @queue.shutdown
-
-      assert_same subject, despawned_worker
-    end
-
-    should "raise an error on the thread using `raise`" do
-      subject.on_work = proc do |work|
-        begin
-          sleep 1
-        rescue RuntimeError => error
-          @work_done << error
-          raise error
-        end
-      end
-      subject.start
-      @queue.push 'a'
-      subject.join 0.1 # trigger the worker's thread to run
-
-      exception = RuntimeError.new
-      subject.raise exception
-      assert_equal [exception], @work_done
-    end
-
-  end
-
-  class CallbacksTests < InitSetupTests
-    setup do
-      @call_counter = 0
-
-      @on_start_called_with = nil
-      @on_start_called_at   = nil
-      @worker_class.on_start do |*args|
-        @on_start_called_with = args
-        @on_start_called_at   = (@call_counter += 1)
-      end
-
-      @on_shutdown_called_with = nil
-      @on_shutdown_called_at   = nil
-      @worker_class.on_shutdown do |*args|
-        @on_shutdown_called_with = args
-        @on_shutdown_called_at   = (@call_counter += 1)
-      end
-
-      @on_sleep_called_with = nil
-      @on_sleep_called_at   = nil
-      @worker_class.on_sleep do |*args|
-        @on_sleep_called_with = args
-        @on_sleep_called_at   = (@call_counter += 1)
-      end
-
-      @on_wakeup_called_with = nil
-      @on_wakeup_called_at   = nil
-      @worker_class.on_wakeup do |*args|
-        @on_wakeup_called_with = args
-        @on_wakeup_called_at   = (@call_counter += 1)
-      end
-
-      @on_error_called_with = nil
-      @worker_class.on_error{ |*args| @on_error_called_with = args }
-
-      @before_work_called_with = nil
-      @before_work_called_at   = nil
-      @worker_class.before_work do |*args|
-        @before_work_called_with = args
-        @before_work_called_at   = (@call_counter += 1)
-      end
-
-      @after_work_called_with  = nil
-      @after_work_called_at    = nil
-      @worker_class.after_work do |*args|
-        @after_work_called_with = args
-        @after_work_called_at   = (@call_counter += 1)
-      end
 
       @worker = @worker_class.new(@runner, @queue)
+      @worker.on_work = proc{ |work_item| @work_done << work_item }
+    end
+    teardown do
+      @worker.shutdown
+      @queue.shutdown
+      @worker.join
     end
     subject{ @worker }
 
-    should "pass its self to its start, shutdown, sleep and wakeup callbacks" do
+    should have_accessors :on_work
+
+    should "call the block it's passed when it gets work from the queue" do
       subject.start
-      @queue.push('work')
-      subject.shutdown
-      @queue.shutdown
+      work_items = Factory.integer(3).times.map{ Factory.string }
+      work_items.each{ |work_item| @queue.push(work_item) }
 
-      assert_equal [subject], @on_start_called_with
-      assert_equal [subject], @on_shutdown_called_with
-      assert_equal [subject], @on_sleep_called_with
-      assert_equal [subject], @on_wakeup_called_with
-    end
-
-    should "pass its self and work to its before and after work callbacks" do
-      subject.start
-      @queue.push('work')
-      subject.shutdown
-      @queue.shutdown
-
-      assert_equal [subject, 'work'], @before_work_called_with
-      assert_equal [subject, 'work'], @after_work_called_with
-    end
-
-    should "call its callbacks throughout its lifecycle" do
-      subject.start
-      assert_equal 1, @on_start_called_at
-      assert_equal 2, @on_sleep_called_at
-      @queue.push('work')
-      assert_equal 3, @on_wakeup_called_at
-      assert_equal 4, @before_work_called_at
-      assert_equal 5, @after_work_called_at
-      assert_equal 6, @on_sleep_called_at
-      subject.shutdown
-      @queue.shutdown
-      assert_equal 7, @on_wakeup_called_at
-      assert_equal 8, @on_shutdown_called_at
-    end
-
-    should "call its error callbacks when an exception occurs" do
-      exception = RuntimeError.new
-      subject.on_work = proc{ raise exception }
-      thread = subject.start
-      @queue.push('work')
-      assert_equal [subject, exception, 'work'], @on_error_called_with
-      assert_true thread.alive?
-    end
-
-    should "call its error callbacks when an shutdown error occurs and reraise" do
-      exception = DatWorkerPool::ShutdownError.new
-      subject.on_work = proc{ raise exception }
-      thread = subject.start
-      @queue.push('work')
-      assert_equal [subject, exception, 'work'], @on_error_called_with
-      assert_false thread.alive?
-      # ensure the shutdown error is handled and isn't thrown when we join
-      assert_nothing_raised{ thread.join }
+      subject.join 0.1 # trigger the workers thread to run
+      assert_equal work_items, @work_done
     end
 
   end

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -1,6 +1,10 @@
 require 'assert'
 require 'dat-worker-pool/worker'
 
+require 'system_timer'
+require 'dat-worker-pool/default_queue'
+require 'dat-worker-pool/runner'
+
 module DatWorkerPool::Worker
 
   class UnitTests < Assert::Context
@@ -101,10 +105,398 @@ module DatWorkerPool::Worker
       assert_equal callback, subject.after_work_callbacks.first
     end
 
+    def shutdown_worker_queue_and_wait_for_thread_to_stop
+      @worker.shutdown if @worker
+      @queue.shutdown
+      wait_for_worker_thread_to_stop
+    end
+
+    def wait_for_worker_thread_to_stop
+      SystemTimer.timeout(1){ @worker.join } if @worker
+    end
+
   end
 
   class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @queue  = DatWorkerPool::DefaultQueue.new.tap(&:start)
+      @runner = DatWorkerPool::Runner.new(:queue => @queue)
 
+      @worker = TestWorker.new(@runner, @queue)
+    end
+    teardown do
+      shutdown_worker_queue_and_wait_for_thread_to_stop
+    end
+    subject{ @worker }
+
+    should have_imeths :work
+    should have_imeths :start, :shutdown, :running?, :shutdown?
+    should have_imeths :thread_alive?, :join, :raise
+
+    should "call `work!` and its before/after work callbacks using `work`" do
+      work_item = Factory.string
+      subject.work(work_item)
+
+      assert_same work_item, subject.before_work_item_worked_on
+      assert_same work_item, subject.item_worked_on
+      assert_same work_item, subject.after_work_item_worked_on
+    end
+
+    should "start a thread when its started" do
+      thread = subject.start
+
+      assert_instance_of Thread, thread
+      assert_true thread.alive?
+    end
+
+    should "know if its running and if its thread is alive or not" do
+      assert_false subject.running?
+      assert_false subject.thread_alive?
+
+      subject.start
+      assert_true subject.running?
+      assert_true subject.thread_alive?
+
+      subject.shutdown
+      assert_false subject.running?
+      assert_true subject.thread_alive?
+
+      shutdown_worker_queue_and_wait_for_thread_to_stop
+      assert_false subject.running?
+      assert_false subject.thread_alive?
+    end
+
+    should "despawn itself from its runner when its thread stops" do
+      despawned_worker = nil
+      Assert.stub(@runner, :despawn_worker){ |worker| despawned_worker = worker }
+      subject.start
+
+      shutdown_worker_queue_and_wait_for_thread_to_stop
+      assert_same subject, despawned_worker
+    end
+
+    should "allow joining and raising on its thread" do
+      thread_spy = ThreadSpy.new
+      Assert.stub(Thread, :new){ thread_spy }
+
+      subject.start
+
+      subject.join
+      assert_nil thread_spy.join_seconds
+      assert_true thread_spy.join_called
+
+      seconds = Factory.integer
+      subject.join(seconds)
+      assert_equal seconds, thread_spy.join_seconds
+
+      exception = Factory.exception
+      subject.raise(exception)
+      assert_equal exception, thread_spy.raised_exception
+    end
+
+    should "not allow joining or raising if it hasn't been started" do
+      assert_nothing_raised{ subject.join(Factory.integer) }
+      assert_nothing_raised{ subject.raise(Factory.exception) }
+    end
+
+    should "increment its runners workers waiting everytime it sleeps" do
+      increment_call_count = 0
+      Assert.stub(@runner, :increment_worker_waiting){ increment_call_count += 1 }
+
+      # the worker immediately goes to sleep because there isn't any work
+      subject.start
+      assert_equal 1, increment_call_count
+
+      # the worker wakes up and runs this work item, then goes back to sleep
+      @queue.push(Factory.string)
+      assert_equal 2, increment_call_count
+    end
+
+    should "decrement its runners workers waiting everytime it wakes up" do
+      decrement_call_count = 0
+      Assert.stub(@runner, :decrement_worker_waiting){ decrement_call_count += 1 }
+
+      # the worker immediately goes to sleep because there isn't any work
+      subject.start
+      assert_equal 0, decrement_call_count
+
+      # the worker wakes up and runs this work item
+      @queue.push(Factory.string)
+      assert_equal 1, decrement_call_count
+
+      # the worker wakes up when it and its queue are shut down
+      shutdown_worker_queue_and_wait_for_thread_to_stop
+      assert_equal 2, decrement_call_count
+    end
+
+    should "call its `work` method on any pushed items while running" do
+      assert_nil subject.item_worked_on
+      subject.start
+      assert_nil subject.item_worked_on
+
+      work_item = Factory.string
+      @queue.push(work_item)
+      assert_equal work_item, subject.item_worked_on
+    end
+
+    should "not call its `work` method if it pops a `nil` work item" do
+      subject.start
+
+      @queue.push(nil)
+      assert_false subject.work_called
+
+      # when the queue is shutdown it returns `nil`, so we shouldn't call `work`
+      # when shutting down
+      shutdown_worker_queue_and_wait_for_thread_to_stop
+      assert_false subject.work_called
+    end
+
+    should "not stop its thread when an error occurs while running" do
+      exception = Factory.exception
+      setup_work_loop_to_raise_exception(exception)
+      subject.start
+
+      @queue.push(Factory.string)
+      assert_true subject.thread_alive?
+    end
+
+    should "run its on-error callbacks if an error occurs while running" do
+      exception = Factory.exception
+      error_method = setup_work_loop_to_raise_exception(exception)
+      subject.start
+      work_item = Factory.string
+      @queue.push(work_item)
+
+      assert_equal exception, subject.on_error_exception
+      # the on-sleep callback will not include a work item if it errors
+      exp = error_method == :on_sleep_error ? nil : work_item
+      assert_equal exp, subject.on_error_work_item
+    end
+
+    should "stop its thread when a shutdown error is raised while running" do
+      exception = Factory.exception(DatWorkerPool::ShutdownError)
+      setup_work_loop_to_raise_exception(exception)
+      subject.start
+      @queue.push(Factory.string)
+
+      wait_for_worker_thread_to_stop
+      assert_false subject.thread_alive?
+    end
+
+    should "not re-raise a shutdown error when joined" do
+      exception = Factory.exception(DatWorkerPool::ShutdownError)
+      setup_work_loop_to_raise_exception(exception)
+      subject.start
+      @queue.push(Factory.string)
+
+      SystemTimer.timeout(1) do
+        assert_nothing_raised{ subject.join }
+      end
+    end
+
+    should "run its on-error callbacks when a shutdown error is raised while running" do
+      exception = Factory.exception(DatWorkerPool::ShutdownError)
+      error_method = setup_work_loop_to_raise_exception(exception)
+      subject.start
+      work_item = Factory.string
+      @queue.push(work_item)
+
+      assert_equal exception, subject.on_error_exception
+      # the on-sleep callback will not include a work item if it errors
+      exp = error_method == :on_sleep_error ? nil : work_item
+      assert_equal exp, subject.on_error_work_item
+    end
+
+    should "run callbacks when its started" do
+      assert_nil subject.first_on_start_call_order
+      assert_nil subject.second_on_start_call_order
+      assert_nil subject.first_on_sleep_call_order
+      assert_nil subject.second_on_sleep_call_order
+
+      subject.start
+
+      assert_equal 1, subject.first_on_start_call_order
+      assert_equal 2, subject.second_on_start_call_order
+      assert_equal 3, subject.first_on_sleep_call_order
+      assert_equal 4, subject.second_on_sleep_call_order
+    end
+
+    should "run its callbacks when work is pushed" do
+      subject.start
+      subject.reset_call_order
+
+      assert_nil subject.first_on_sleep_call_order
+      assert_nil subject.second_on_sleep_call_order
+      assert_nil subject.first_before_work_call_order
+      assert_nil subject.second_before_work_call_order
+      assert_nil subject.work_call_order
+      assert_nil subject.first_after_work_call_order
+      assert_nil subject.second_after_work_call_order
+      assert_nil subject.first_on_wakeup_call_order
+      assert_nil subject.second_on_wakeup_call_order
+
+      @queue.push(Factory.string)
+
+      assert_equal 1, subject.first_on_wakeup_call_order
+      assert_equal 2, subject.second_on_wakeup_call_order
+      assert_equal 3, subject.first_before_work_call_order
+      assert_equal 4, subject.second_before_work_call_order
+      assert_equal 5, subject.work_call_order
+      assert_equal 6, subject.first_after_work_call_order
+      assert_equal 7, subject.second_after_work_call_order
+      assert_equal 8, subject.first_on_sleep_call_order
+      assert_equal 9, subject.second_on_sleep_call_order
+    end
+
+    should "run callbacks when its shutdown" do
+      subject.start
+      subject.reset_call_order
+
+      assert_nil subject.first_on_wakeup_call_order
+      assert_nil subject.second_on_wakeup_call_order
+      assert_nil subject.first_on_shutdown_call_order
+      assert_nil subject.second_on_shutdown_call_order
+
+      shutdown_worker_queue_and_wait_for_thread_to_stop
+
+      assert_equal 1, subject.first_on_wakeup_call_order
+      assert_equal 2, subject.second_on_wakeup_call_order
+      assert_equal 3, subject.first_on_shutdown_call_order
+      assert_equal 4, subject.second_on_shutdown_call_order
+    end
+
+    ERROR_METHODS = [
+      :on_sleep_error,
+      :on_wakeup_error,
+      :before_work_error,
+      :work_error,
+      :after_work_error
+    ].freeze
+    def setup_work_loop_to_raise_exception(exception)
+      error_method = ERROR_METHODS.choice
+      @worker.send("#{error_method}=", exception)
+      error_method
+    end
+
+  end
+
+  class TestWorker
+    include DatWorkerPool::Worker
+
+    attr_accessor :first_on_start_call_order, :second_on_start_call_order
+    attr_accessor :first_on_shutdown_call_order, :second_on_shutdown_call_order
+    attr_accessor :first_on_sleep_call_order, :second_on_sleep_call_order
+    attr_accessor :first_on_wakeup_call_order, :second_on_wakeup_call_order
+    attr_accessor :first_before_work_call_order, :second_before_work_call_order
+    attr_accessor :first_after_work_call_order, :second_after_work_call_order
+    attr_accessor :work_call_order
+
+    attr_accessor :before_work_item_worked_on, :after_work_item_worked_on
+    attr_accessor :item_worked_on
+
+    attr_accessor :on_sleep_error, :on_wakeup_error
+    attr_accessor :before_work_error, :after_work_error
+    attr_accessor :work_error
+
+    attr_accessor :on_error_exception, :on_error_work_item
+
+    # TODO - change once these are instance evald
+    on_start{ |w| w.first_on_start_call_order  = w.next_call_order }
+    on_start{ |w| w.second_on_start_call_order = w.next_call_order }
+
+    on_shutdown{ |w| w.first_on_shutdown_call_order  = w.next_call_order }
+    on_shutdown{ |w| w.second_on_shutdown_call_order = w.next_call_order }
+
+    on_sleep{ |w| w.first_on_sleep_call_order  = w.next_call_order }
+    on_sleep do |w|
+      w.raise_error_if_set(:on_sleep)
+      w.second_on_sleep_call_order = w.next_call_order
+    end
+
+    on_wakeup{ |w| w.first_on_wakeup_call_order  = w.next_call_order }
+    on_wakeup do |w|
+      w.raise_error_if_set(:on_wakeup)
+      w.second_on_wakeup_call_order = w.next_call_order
+    end
+
+    before_work{ |w, work_item| w.first_before_work_call_order = w.next_call_order }
+    before_work do |w, work_item|
+      w.raise_error_if_set(:before_work)
+      w.before_work_item_worked_on    = work_item
+      w.second_before_work_call_order = w.next_call_order
+    end
+
+    after_work{ |w, work_item| w.first_after_work_call_order = w.next_call_order }
+    after_work do |w, work_item|
+      w.raise_error_if_set(:after_work)
+      w.after_work_item_worked_on    = work_item
+      w.second_after_work_call_order = w.next_call_order
+    end
+
+    on_error do |w, exception, work_item|
+      w.on_error_exception = exception
+      w.on_error_work_item = work_item
+    end
+
+    def work!(work_item)
+      raise_error_if_set(:work)
+      @work_called     = true
+      @item_worked_on  = work_item
+      @work_call_order = next_call_order
+    end
+
+    def work_called; !!@work_called; end
+
+    def reset_call_order
+      @order = 0
+      @first_on_start_call_order     = nil
+      @second_on_start_call_order    = nil
+      @first_on_shutdown_call_order  = nil
+      @second_on_shutdown_call_order = nil
+      @first_on_sleep_call_order     = nil
+      @second_on_sleep_call_order    = nil
+      @first_on_wakeup_call_order    = nil
+      @second_on_wakeup_call_order   = nil
+      @first_before_work_call_order  = nil
+      @second_before_work_call_order = nil
+      @first_after_work_call_order   = nil
+      @second_after_work_call_order  = nil
+      @work_call_order               = nil
+    end
+
+    def next_call_order; @order = (@order || 0) + 1; end
+
+    # we want to unset the error method if its set to avoid the thread looping
+    # very quickly because it doesn't sleep on `queue.pop`
+    def raise_error_if_set(type)
+      if (error = self.send("#{type}_error"))
+        self.send("#{type}_error=", nil)
+        Thread.current.raise error
+      end
+    end
+  end
+
+  class ThreadSpy
+    attr_reader :join_seconds, :join_called
+    attr_reader :raised_exception
+
+    def initialize
+      @join_seconds     = nil
+      @join_called      = false
+      @raised_exception = nil
+    end
+
+    def join(seconds = nil)
+      @join_seconds = seconds
+      @join_called  = true
+    end
+
+    def raise(exception)
+      @raised_exception = exception
+    end
+
+    def alive?; true; end
   end
 
 end


### PR DESCRIPTION
This adds the rest of the logic from `DefaultWorker` to the
`Worker` mixin. This fills out the worker with all the logic
needed to define custom workers.

The `Worker` mixin now contains all the logic needed to define
custom workers. It knows how to start, shutdown and process work
items while running. Most of the logic was copied straight out of
the default worker but a few things were changed:

* The mixin now expects a `work!` method to be defined. This is
  tells it how to process a work item. It doesn't accept an on
  work proc.
* Switch from a shutdown flag to a running flag. This is consistent
  with queues and makes the default state of the worker not running
  (shutdown).
* This changes the `running?` method to be based on the running
  flag instead of if the thread is alive. This is for consistency
  with queues. This adds a `thread_alive?` to check if the thread
  is alive. This gives us the ability to ask if the worker has been
  shutdown even if its thread is still alive (meaning its in the
  process of shutting down).

This also redoes the unit tests for the logic that was moved to the
`Worker` mixin. They have been improved with more detailed and
granular testing of the worker behavior. They also use our latest
testing conventions.

Finally, this removes most of the logic from `DefaultWorker` only
leaving its `on_work` proc. It now uses the `work!` interface that
the `Worker` mixin expects and calls its `on_work` proc.

@kellyredding - Ready for review.