### PR TITLE
Change worker callbacks, instance exec and begin-rescue them

### DIFF
--- a/test/system/use_worker_pool_tests.rb
+++ b/test/system/use_worker_pool_tests.rb
@@ -95,17 +95,16 @@ class DatWorkerPool
       @worker_class = Class.new do
         include DatWorkerPool::Worker
 
-        # TODO - change once these are instance evald
-        on_start{ |w| w.params[:callbacks_called][:on_start] = true }
-        on_shutdown{ |w| w.params[:callbacks_called][:on_shutdown] = true }
+        on_start{ params[:callbacks_called][:on_start] = true }
+        on_shutdown{ params[:callbacks_called][:on_shutdown] = true }
 
-        on_sleep{ |w| w.params[:callbacks_called][:on_sleep] = true }
-        on_wakeup{ |w| w.params[:callbacks_called][:on_wakeup] = true }
+        on_sleep{ params[:callbacks_called][:on_sleep] = true }
+        on_wakeup{ params[:callbacks_called][:on_wakeup] = true }
 
-        on_error{ |w, e, wi| w.params[:callbacks_called][:on_error] = true }
+        on_error{ |e, wi| params[:callbacks_called][:on_error] = true }
 
-        before_work{ |w, wi| w.params[:callbacks_called][:before_work] = true }
-        after_work{ |w, wi| w.params[:callbacks_called][:after_work] = true }
+        before_work{ |wi| params[:callbacks_called][:before_work] = true }
+        after_work{ |wi| params[:callbacks_called][:after_work] = true }
 
         def work!(work_item); raise work_item if work_item == 'error'; end
       end


### PR DESCRIPTION
This changes the worker callbacks to be instance exec'd, wraps
the on-start and on-shutdown in begin-rescues and changes the
worker to spawn itself with the runner when its started. This is
to make the callbacks more consistent and safer (keep them from
messing up the worker behavior).

The worker callbacks are now instance exec'd instead of being
called. This makes them more consistent with the `work!` method
and lets them easily access the queue and params.  As part of this,
the internal methods and ivars for the workers behavior have been
namespaced to avoid user defined methods and ivars.

This also wraps the on-start and on-shutdown callbacks in
begin-rescues. This is to ensure that if they raise an error, the
on-error callbacks get called. This also tries to keep the errors
from keeping workers from starting or shutting down incorrectly.

Finally, this changes the worker to call a `spawn_worker` method
on the runner when it starts. This is consistent with how it calls
`despawn_worker` when it shuts down. The `spawn_worker` adds the
worker to the runners workers just like the `despawn_worker`
removes it. This makes sure we don't add the worker to the
collection before the thread has started and gotten to run (meaning
its actually processing work).

@kellyredding - Ready for review.