### PR TITLE
Changes to shutdown logic

### DIFF
--- a/lib/dat-worker-pool.rb
+++ b/lib/dat-worker-pool.rb
@@ -43,7 +43,7 @@ class DatWorkerPool
   end
 
   def shutdown(timeout = nil)
-    @runner.shutdown(timeout)
+    @runner.shutdown(timeout, caller)
   end
 
   def add_work(work_item)
@@ -68,8 +68,6 @@ class DatWorkerPool
       define_method(name.downcase){ |*args| } # no-op
     end
   end
-
-  TimeoutError = Class.new(RuntimeError)
 
   # this error should never be "swallowed", if it is caught be sure to re-raise
   # it so the workers shutdown; otherwise workers will get killed

--- a/lib/dat-worker-pool/queue.rb
+++ b/lib/dat-worker-pool/queue.rb
@@ -15,8 +15,12 @@ class DatWorkerPool
         start!
       end
 
-      def shutdown
+      def signal_shutdown
         @running = false
+      end
+
+      def shutdown
+        self.signal_shutdown
         shutdown!
       end
 

--- a/lib/dat-worker-pool/runner.rb
+++ b/lib/dat-worker-pool/runner.rb
@@ -29,19 +29,26 @@ class DatWorkerPool
     # the workers should be told to shutdown before the queue because the queue
     # shutdown will wake them up; a worker popping on a shutdown queue will
     # always get `nil` back and will loop as fast as allowed until its shutdown
-    # flag is flipped, so shutting down the workers then the queue keeps them from
-    # looping as fast as possible; use an until loop instead of each to join all
-    # the workers, while we are joining a worker a different worker can shutdown
-    # and remove itself from the `@workers` array
-    def shutdown(timeout = nil)
+    # flag is flipped, so shutting down the workers then the queue keeps them
+    # from looping as fast as possible; if any kind of standard error or the
+    # expected timeout error (assuming the workers take too long to shutdown) is
+    # raised, force a shutdown; this ensures we shutdown as best as possible
+    # instead of letting ruby kill the threads when the process exits;
+    # non-timeout errors will be re-raised so they can be caught and handled (or
+    # shown when the process exits)
+    def shutdown(timeout = nil, backtrace = nil)
       begin
+        @workers.each(&:dwp_signal_shutdown)
+        @queue.signal_shutdown
         OptionalTimeout.new(timeout) do
-          @workers.each(&:dwp_shutdown)
           @queue.shutdown
-          @workers.first.dwp_join until @workers.empty?
+          wait_for_workers_to_shutdown
         end
-      rescue TimeoutError
-        force_shutdown(timeout, caller)
+      rescue StandardError => exception
+        force_workers_to_shutdown(exception, timeout, backtrace)
+        raise exception
+      rescue TimeoutInterruptError => exception
+        force_workers_to_shutdown(exception, timeout, backtrace)
       end
     end
 
@@ -73,31 +80,67 @@ class DatWorkerPool
 
     # use an until loop instead of each to join all the workers, while we are
     # joining a worker a different worker can shutdown and remove itself from
-    # the `@workers` array; `rescue false` when joining the workers, ruby will
-    # raise any exceptions that aren't handled by a thread when its joined, this
-    # ensures if the hard shutdown is raised and not rescued (for example, in
-    # the workers ensure), then it won't cause the forced shutdown to end
+    # the `@workers` array; rescue when joining the workers, ruby will raise any
+    # exceptions that aren't handled by a thread when its joined, this allows
+    # all the workers to be joined
+    def wait_for_workers_to_shutdown
+      until @workers.empty?
+        worker = @workers.first
+        begin
+          worker.dwp_join
+        rescue StandardError
+          self.remove_worker(worker)
+        end
+      end
+    end
+
+    # use an until loop instead of each to join all the workers, while we are
+    # joining a worker a different worker can shutdown and remove itself from
+    # the `@workers` array; rescue when joining the workers, ruby will raise any
+    # exceptions that aren't handled by a thread when its joined, this ensures
+    # if the hard shutdown is raised and not rescued (for example, in the
+    # workers ensure), then it won't cause the forced shutdown to end
     # prematurely
-    def force_shutdown(timeout, backtrace)
-      error = ShutdownError.new("Timed out shutting down (#{timeout} seconds).")
-      error.set_backtrace(backtrace)
+    def force_workers_to_shutdown(orig_exception, timeout, backtrace)
+      error = build_forced_shutdown_error(orig_exception, timeout, backtrace)
       until @workers.empty?
         worker = @workers.first
         worker.dwp_raise(error)
-        worker.dwp_join rescue false
-        @workers.delete(worker)
+        begin
+          worker.dwp_join
+        rescue StandardError, ShutdownError
+        end
+        self.remove_worker(worker)
+      end
+    end
+
+    def build_forced_shutdown_error(orig_exception, timeout, backtrace)
+      if orig_exception.kind_of?(TimeoutInterruptError)
+        ShutdownError.new("Timed out shutting down (#{timeout} seconds).").tap do |e|
+          e.set_backtrace(backtrace) if backtrace
+        end
+      else
+        ShutdownError.new("Errored while shutting down: #{orig_exception.inspect}").tap do |e|
+          e.set_backtrace(orig_exception.backtrace)
+        end
       end
     end
 
     module OptionalTimeout
       def self.new(seconds, &block)
         if seconds
-          SystemTimer.timeout(seconds, TimeoutError, &block)
+          SystemTimer.timeout(seconds, TimeoutInterruptError, &block)
         else
           block.call
         end
       end
     end
+
+    # this needs to be an `Interrupt` to be sure we don't accidentally catch it
+    # when rescueing exceptions; in the shutdown methods we rescue any errors
+    # from `worker.join`, this will also rescue the timeout error if its a
+    # standard error and will keep it from doing a forced shutdown
+    TimeoutInterruptError = Class.new(Interrupt)
 
     class WorkersWaiting
       attr_reader :count

--- a/test/unit/dat-worker-pool_tests.rb
+++ b/test/unit/dat-worker-pool_tests.rb
@@ -97,6 +97,8 @@ class DatWorkerPool
       subject.shutdown
       assert_true @runner_spy.shutdown_called
       assert_nil @runner_spy.shutdown_timeout
+      exp = "test/unit/dat-worker-pool_tests.rb"
+      assert_match exp, @runner_spy.shutdown_backtrace.first
 
       timeout = Factory.integer
       subject.shutdown(timeout)
@@ -171,13 +173,15 @@ class DatWorkerPool
 
   class RunnerSpy < DatWorkerPool::Runner
     attr_accessor :args
-    attr_reader :start_called, :shutdown_timeout, :shutdown_called
+    attr_reader :start_called, :shutdown_called
+    attr_reader :shutdown_timeout, :shutdown_backtrace
 
     def initialize
       super({})
-      @start_called     = false
-      @shutdown_timeout = nil
-      @shutdown_called  = false
+      @start_called       = false
+      @shutdown_called    = false
+      @shutdown_timeout   = nil
+      @shutdown_backtrace = nil
     end
 
     def start
@@ -185,10 +189,11 @@ class DatWorkerPool
       @start_called = true
     end
 
-    def shutdown(timeout)
+    def shutdown(timeout, backtrace)
       @args[:queue].shutdown
-      @shutdown_timeout = timeout
-      @shutdown_called  = true
+      @shutdown_called    = true
+      @shutdown_timeout   = timeout
+      @shutdown_backtrace = backtrace
     end
   end
 

--- a/test/unit/queue_tests.rb
+++ b/test/unit/queue_tests.rb
@@ -46,7 +46,8 @@ module DatWorkerPool::Queue
     end
     subject{ @queue }
 
-    should have_imeths :start, :shutdown, :running?, :shutdown?
+    should have_imeths :start, :signal_shutdown, :shutdown
+    should have_imeths :running?, :shutdown?
     should have_imeths :push, :pop
 
     should "set its flags using `start` and `shutdown`" do
@@ -64,6 +65,17 @@ module DatWorkerPool::Queue
       assert_false subject.start_called
       subject.start
       assert_true subject.start_called
+    end
+
+    should "set its shutdown flag using `signal_shutdown`" do
+      assert_false subject.running?
+      assert_false subject.shutdown_called
+      subject.start
+      assert_true  subject.running?
+      assert_false subject.shutdown_called
+      subject.signal_shutdown
+      assert_false subject.running?
+      assert_false subject.shutdown_called
     end
 
     should "call `shutdown!` using `shutdown`" do


### PR DESCRIPTION
This is a number of small changes to the shutdown logic. In general
these are related to error handling when shutting down. Now that
its possible for queues and workers to be customized its possible
for more errors to be introduced. This ensures we cover those
scenarios and try to report the errors as much as possible.

* The workers and queue are now signalled to shutdown outside the
timeout so they will always be "shutdown" even if the timeout is
short.

* Runner shutdown will now rescue errors when joining workers and
if an error occurs it will manually remove it. This ensures that if
a worker errors it doesn't get the other workers killed when they
could shutdown normally.

* Runner shutdown will now catch standard errors that are thrown
and do a forced shutdown. This avoids the process exiting and
the workers getting killed. The error will be re-raised after the
runner has finished shutting down.

* The `TimoutError` is now named `TimeoutInterruptError` and is
not a standard error. The timeout error is typically thrown from
the `worker.join` which is now rescued. This caused the shutdown to
no longer timeout. This error is like the shutdown error, its
internal and shouldn't be rescued.

* Fixes the forced shutdown error backtrace to once again be
the caller of the dat-worker-pool `shutdown` method. This keeps
the backtrace out of the internals of the worker and makes it
relevant to what action caused the error. This was what it was set
to before we added a `Runner`.

* Fixes the runner shutdown tests to ensure they actually test
workers. Previously they would rely on the runners workers array
to do assertions but this array is not safe because it is emptied
as the workers shutdown. The tests now get a copy of the workers
array and use that to do their assertions.

@kellyredding - Ready for review.