### PR TITLE
Update `WorkerPoolSpy` and add `Worker::TestHelpers`

### DIFF
--- a/lib/dat-worker-pool/worker_pool_spy.rb
+++ b/lib/dat-worker-pool/worker_pool_spy.rb
@@ -2,37 +2,33 @@ class DatWorkerPool
 
   class WorkerPoolSpy
 
-    attr_reader :num_workers, :debug
-    attr_reader :work_proc, :work_items
-    attr_reader :start_called
-    attr_reader :shutdown_called, :shutdown_timeout
-    attr_reader :on_queue_pop_callbacks, :on_queue_push_callbacks
-    attr_reader :on_worker_error_callbacks
-    attr_reader :on_worker_start_callbacks, :on_worker_shutdown_callbacks
-    attr_reader :on_worker_sleep_callbacks, :on_worker_wakeup_callbacks
-    attr_reader :before_work_callbacks, :after_work_callbacks
+    attr_reader :logger, :queue
+    attr_reader :options, :num_workers, :worker_class, :worker_params
+    attr_reader :work_items
+    attr_reader :start_called, :shutdown_called, :shutdown_timeout
     attr_accessor :worker_available
 
-    def initialize(num_workers = 1, debug = false, &block)
-      @num_workers = num_workers
-      @debug       = debug
-      @work_proc   = block
+    def initialize(worker_class, options = nil)
+      @worker_class = worker_class
+      if !@worker_class.kind_of?(Class) || !@worker_class.include?(DatWorkerPool::Worker)
+        raise ArgumentError, "worker class must include `#{DatWorkerPool::Worker}`"
+      end
+
+      @options      = options
+      @num_workers  = @options[:num_workers].to_i
+      if @num_workers && @num_workers < MIN_WORKERS
+        raise ArgumentError, "number of workers must be at least #{MIN_WORKERS}"
+      end
+
+      @logger        = @options[:logger]
+      @queue         = @options[:queue]
+      @worker_params = @options[:worker_params]
 
       @worker_available = false
-      @work_items = []
-      @start_called = false
+      @work_items       = []
+      @start_called     = false
       @shutdown_called  = false
       @shutdown_timeout = nil
-
-      @on_queue_pop_callbacks       = []
-      @on_queue_push_callbacks      = []
-      @on_worker_error_callbacks    = []
-      @on_worker_start_callbacks    = []
-      @on_worker_shutdown_callbacks = []
-      @on_worker_sleep_callbacks    = []
-      @on_worker_wakeup_callbacks   = []
-      @before_work_callbacks        = []
-      @after_work_callbacks         = []
     end
 
     def start
@@ -40,39 +36,22 @@ class DatWorkerPool
     end
 
     def shutdown(timeout = nil)
-      @shutdown_called = true
+      @shutdown_called  = true
       @shutdown_timeout = timeout
     end
 
-    def add_work(work)
-      return unless work
-      @work_items << work
-      @on_queue_push_callbacks.each(&:call)
+    def add_work(work_item)
+      return if work_item.nil?
+      @work_items << work_item
     end
 
-    def pop_work
-      work = @work_items.shift
-      @on_queue_pop_callbacks.each(&:call)
-      work
-    end
-
-    def queue_empty?
-      @work_items.empty?
+    def waiting
+      @num_workers
     end
 
     def worker_available?
-      @worker_available
+      !!@worker_available
     end
-
-    def on_queue_pop(&block);       @on_queue_pop_callbacks       << block; end
-    def on_queue_push(&block);      @on_queue_push_callbacks      << block; end
-    def on_worker_error(&block);    @on_worker_error_callbacks    << block; end
-    def on_worker_start(&block);    @on_worker_start_callbacks    << block; end
-    def on_worker_shutdown(&block); @on_worker_shutdown_callbacks << block; end
-    def on_worker_sleep(&block);    @on_worker_sleep_callbacks    << block; end
-    def on_worker_wakeup(&block);   @on_worker_wakeup_callbacks   << block; end
-    def before_work(&block);        @before_work_callbacks        << block; end
-    def after_work(&block);         @after_work_callbacks         << block; end
 
   end
 

--- a/test/unit/worker_pool_spy_tests.rb
+++ b/test/unit/worker_pool_spy_tests.rb
@@ -1,143 +1,93 @@
 require 'assert'
 require 'dat-worker-pool/worker_pool_spy'
 
+require 'dat-worker-pool'
+require 'dat-worker-pool/default_queue'
+require 'dat-worker-pool/worker'
+
 class DatWorkerPool::WorkerPoolSpy
 
   class UnitTests < Assert::Context
     desc "DatWorkerPool::WorkerPoolSpy"
     setup do
-      @work_proc = proc{ 'work' }
-      @worker_pool_spy = DatWorkerPool::WorkerPoolSpy.new(&@work_proc)
+      @spy_class = DatWorkerPool::WorkerPoolSpy
+    end
+    subject{ @spy_class }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @worker_class = Class.new{ include DatWorkerPool::Worker }
+      @options = {
+        :num_workers   => Factory.integer,
+        :logger        => DatWorkerPool::NullLogger.new,
+        :queue         => DatWorkerPool::DefaultQueue.new,
+        :worker_params => { Factory.string => Factory.string }
+      }
+
+      @worker_pool_spy = @spy_class.new(@worker_class, @options)
     end
     subject{ @worker_pool_spy }
 
-    should have_readers :num_workers, :debug
-    should have_readers :work_proc, :work_items
+    should have_readers :logger, :queue
+    should have_readers :options, :num_workers, :worker_class, :worker_params
+    should have_readers :work_items
     should have_readers :start_called, :shutdown_called, :shutdown_timeout
-    should have_readers :on_queue_pop_callbacks, :on_queue_push_callbacks
-    should have_readers :on_worker_error_callbacks
-    should have_readers :on_worker_start_callbacks, :on_worker_shutdown_callbacks
-    should have_readers :on_worker_sleep_callbacks, :on_worker_wakeup_callbacks
-    should have_readers :before_work_callbacks, :after_work_callbacks
     should have_accessors :worker_available
-    should have_imeths :worker_available?, :queue_empty?
-    should have_imeths :add_work, :start, :shutdown
-    should have_imeths :on_queue_pop, :on_queue_push
-    should have_imeths :on_worker_error
-    should have_imeths :on_worker_start, :on_worker_shutdown
-    should have_imeths :on_worker_sleep, :on_worker_wakeup
-    should have_imeths :before_work, :after_work
 
-    should "know its work proc" do
-      assert_equal @work_proc, subject.work_proc
-    end
+    should "know its attributes" do
+      assert_equal @worker_class,            subject.worker_class
+      assert_equal @options,                 subject.options
+      assert_equal @options[:num_workers],   subject.num_workers
+      assert_equal @options[:logger],        subject.logger
+      assert_equal @options[:queue],         subject.queue
+      assert_equal @options[:worker_params], subject.worker_params
 
-    should "have nothing in it's work items by default" do
-      assert subject.work_items.empty?
-    end
-
-    should "not have a worker available by default" do
-      assert_equal false, subject.worker_available
-      assert_not subject.worker_available?
-    end
-
-    should "return false for start called by default" do
-      assert_equal false, subject.start_called
-    end
-
-    should "return false for shutdown called by default" do
-      assert_equal false, subject.shutdown_called
-    end
-
-    should "return `nil` for shutdown timeout by default" do
+      assert_false subject.worker_available?
+      assert_equal [], subject.work_items
+      assert_false subject.start_called
+      assert_false subject.shutdown_called
       assert_nil subject.shutdown_timeout
     end
 
     should "allow setting whether a worker is available" do
       subject.worker_available = true
-      assert_equal true, subject.worker_available
-      assert subject.worker_available?
+      assert_true subject.worker_available?
+      subject.worker_available = false
+      assert_false subject.worker_available?
     end
 
-    should "allow adding work to the work items with #add_work" do
-      subject.add_work 'work'
-      assert_equal 1, subject.work_items.size
-      assert_includes 'work', subject.work_items
-    end
-
-    should "not add `nil` work to the work items with #add_work" do
-      subject.add_work nil
-      assert_equal 0, subject.work_items.size
-    end
-
-    should "return whether the work items is empty with #queue_empty?" do
-      assert_equal true, subject.queue_empty?
-      subject.add_work 'work'
-      assert_equal false, subject.queue_empty?
-    end
-
-    should "know when it's been started" do
+    should "know if it's been started" do
+      assert_false subject.start_called
       subject.start
       assert_true subject.start_called
     end
 
-    should "know when it's been shutdown and with what timeout" do
-      subject.shutdown(10)
-      assert_true subject.shutdown_called
-      assert_equal 10, subject.shutdown_timeout
-    end
-
-    should "allow calling shutdown with no timeout" do
+    should "know if it's been shutdown" do
+      assert_false subject.shutdown_called
       subject.shutdown
       assert_true subject.shutdown_called
       assert_nil subject.shutdown_timeout
     end
 
-    should "know its queue and worker callbacks" do
-      assert_equal [], subject.on_queue_pop_callbacks
-      callback = proc{ }
-      subject.on_queue_pop(&callback)
-      assert_equal [callback], subject.on_queue_pop_callbacks
+    should "know if it's been shutdown with a timeout" do
+      timeout = Factory.integer
+      subject.shutdown(timeout)
+      assert_equal timeout, subject.shutdown_timeout
+    end
 
-      assert_equal [], subject.on_queue_push_callbacks
-      callback = proc{ }
-      subject.on_queue_push(&callback)
-      assert_equal [callback], subject.on_queue_push_callbacks
+    should "allow adding work" do
+      work_item = Factory.string
+      subject.add_work(work_item)
+      assert_equal 1, subject.work_items.size
+      assert_includes work_item, subject.work_items
+    end
 
-      assert_equal [], subject.on_worker_error_callbacks
-      callback = proc{ }
-      subject.on_worker_error(&callback)
-      assert_equal [callback], subject.on_worker_error_callbacks
-
-      assert_equal [], subject.on_worker_start_callbacks
-      callback = proc{ }
-      subject.on_worker_start(&callback)
-      assert_equal [callback], subject.on_worker_start_callbacks
-
-      assert_equal [], subject.on_worker_shutdown_callbacks
-      callback = proc{ }
-      subject.on_worker_shutdown(&callback)
-      assert_equal [callback], subject.on_worker_shutdown_callbacks
-
-      assert_equal [], subject.on_worker_sleep_callbacks
-      callback = proc{ }
-      subject.on_worker_sleep(&callback)
-      assert_equal [callback], subject.on_worker_sleep_callbacks
-
-      assert_equal [], subject.on_worker_wakeup_callbacks
-      callback = proc{ }
-      subject.on_worker_wakeup(&callback)
-      assert_equal [callback], subject.on_worker_wakeup_callbacks
-
-      assert_equal [], subject.before_work_callbacks
-      callback = proc{ }
-      subject.before_work(&callback)
-      assert_equal [callback], subject.before_work_callbacks
-
-      assert_equal [], subject.after_work_callbacks
-      callback = proc{ }
-      subject.after_work(&callback)
-      assert_equal [callback], subject.after_work_callbacks
+    should "not allow adding `nil` work" do
+      subject.add_work(nil)
+      assert_equal 0, subject.work_items.size
     end
 
   end


### PR DESCRIPTION
This updates the worker pool spy with all the changes that were
made to the worker pool. This also adds worker test helpers for
help testing custom workers.

The worker pool spy is a test helper that can be stubbed in as a
replacement to a real worker pool. This updates it so it continues
to provide the same interface as a real worker pool. This keeps it
relevant and useful as a test helper.

This also adds worker test helpers that help with building a worker
and running its behavior. The test runner it builds can be used to
run the workers callbacks and work method separately or all
together. This should help with testing custom worker logic and
making sure it works as expected.

@kellyredding - Ready for review.