### PR TITLE
Switch from sleep/wakeup to unavailable/available callbacks

### DIFF
--- a/lib/dat-worker-pool.rb
+++ b/lib/dat-worker-pool.rb
@@ -51,16 +51,12 @@ class DatWorkerPool
     @queue.push work_item
   end
 
-  def num_workers
-    @runner.num_workers
-  end
-
-  def waiting
-    @runner.workers_waiting_count
+  def available_worker_count
+    @runner.available_worker_count
   end
 
   def worker_available?
-    self.waiting > 0
+    @runner.worker_available?
   end
 
   class NullLogger

--- a/lib/dat-worker-pool/worker_pool_spy.rb
+++ b/lib/dat-worker-pool/worker_pool_spy.rb
@@ -45,10 +45,6 @@ class DatWorkerPool
       @work_items << work_item
     end
 
-    def waiting
-      @num_workers
-    end
-
     def worker_available?
       !!@worker_available
     end

--- a/test/unit/dat-worker-pool_tests.rb
+++ b/test/unit/dat-worker-pool_tests.rb
@@ -60,7 +60,7 @@ class DatWorkerPool
 
     should have_readers :logger, :queue
     should have_imeths :start, :shutdown, :add_work
-    should have_imeths :num_workers, :waiting, :worker_available?
+    should have_imeths :available_worker_count, :worker_available?
 
     should "know its attributes" do
       assert_equal @logger, subject.logger
@@ -106,8 +106,8 @@ class DatWorkerPool
     end
 
     should "demeter its runner" do
-      assert_equal @runner_spy.num_workers,           subject.num_workers
-      assert_equal @runner_spy.workers_waiting_count, subject.waiting
+      assert_equal @runner_spy.available_worker_count, subject.available_worker_count
+      assert_equal @runner_spy.worker_available?,      subject.worker_available?
     end
 
     should "raise an argument error if given an invalid worker class" do


### PR DESCRIPTION
This switches workers from having sleep and wakeup callbacks to
having unavailable and available callbacks. This also switches
from counting the number of waiting workers to a set of available
workers. The goal of this is to be more accurate about the workers
behavior and make it easier to understand when callbacks will
be called.

The workers previous sleep and wakeup callbacks were not always
accurate. It's not possible for the worker to tell if it will
actually go to sleep and wakeup. This switches out the inaccuracy
of those callbacks for worker unavailable/available logic. This
happens when it starts working (it becomes unavailable) and
once it finished working (it becomes available). This is accurate
and less confusing than the previous sleep and wakeup callbacks.

As part of adding in the unavailable/available callbacks, the
`work` method has been made private and renamed to `dwp_work`. This
method was originally public because it was intended to be used as
a test helper. With the test runner though, there is a better
interface to use. This eases the maintenance of the worker because
now we don't also need to worry about keeping its work method
functioning as a test helper.

This also switches the workers waiting count on the runner to an
available workers set. Similarly to the callbacks, this is more
accurate than the workers waiting count. Instead of keeping up with
a count, we add and remove worker object ids from a set. This can
then be used to query whether or not a worker is available or not.

Finally, this removes the `num_workers` and changes the `waiting`
methods from the dat-worker-pool. The `num_workers` method is
confusing because its how many were configured not how many are
actually running. The `waiting` method is now an
`available_worker_count` which returns the number of workers that
are available to do work.

@kellyredding - Ready for review.