### PR TITLE
Namespace `Queue` methods

### DIFF
--- a/lib/dat-worker-pool.rb
+++ b/lib/dat-worker-pool.rb
@@ -48,7 +48,7 @@ class DatWorkerPool
 
   def add_work(work_item)
     return if work_item.nil?
-    @queue.push work_item
+    @queue.dwp_push work_item
   end
 
   def available_worker_count

--- a/lib/dat-worker-pool/queue.rb
+++ b/lib/dat-worker-pool/queue.rb
@@ -10,34 +10,34 @@ class DatWorkerPool
 
     module InstanceMethods
 
-      def start
-        @running = true
+      def dwp_start
+        @dwp_running = true
         start!
       end
 
-      def signal_shutdown
-        @running = false
+      def dwp_signal_shutdown
+        @dwp_running = false
       end
 
-      def shutdown
-        self.signal_shutdown
+      def dwp_shutdown
+        self.dwp_signal_shutdown
         shutdown!
       end
 
       def running?
-        !!@running
+        !!@dwp_running
       end
 
       def shutdown?
         !self.running?
       end
 
-      def push(*args)
+      def dwp_push(*args)
         raise "Unable to add work when shut down" if self.shutdown?
         push!(*args)
       end
 
-      def pop
+      def dwp_pop
         return if self.shutdown?
         pop!
       end

--- a/lib/dat-worker-pool/runner.rb
+++ b/lib/dat-worker-pool/runner.rb
@@ -23,7 +23,7 @@ class DatWorkerPool
     end
 
     def start
-      @queue.start
+      @queue.dwp_start
       @num_workers.times{ build_worker }
     end
 
@@ -40,9 +40,9 @@ class DatWorkerPool
     def shutdown(timeout = nil, backtrace = nil)
       begin
         @workers.each(&:dwp_signal_shutdown)
-        @queue.signal_shutdown
+        @queue.dwp_signal_shutdown
         OptionalTimeout.new(timeout) do
-          @queue.shutdown
+          @queue.dwp_shutdown
           wait_for_workers_to_shutdown
         end
       rescue StandardError => exception

--- a/lib/dat-worker-pool/worker.rb
+++ b/lib/dat-worker-pool/worker.rb
@@ -100,7 +100,7 @@ class DatWorkerPool
         dwp_setup
         while self.dwp_running?
           begin
-            if !(work_item = queue.pop).nil?
+            if !(work_item = queue.dwp_pop).nil?
               begin
                 dwp_make_unavailable
                 dwp_work(work_item)

--- a/test/unit/dat-worker-pool_tests.rb
+++ b/test/unit/dat-worker-pool_tests.rb
@@ -185,12 +185,12 @@ class DatWorkerPool
     end
 
     def start
-      @args[:queue].start
+      @args[:queue].dwp_start
       @start_called = true
     end
 
     def shutdown(timeout, backtrace)
-      @args[:queue].shutdown
+      @args[:queue].dwp_shutdown
       @shutdown_called    = true
       @shutdown_timeout   = timeout
       @shutdown_backtrace = backtrace

--- a/test/unit/queue_tests.rb
+++ b/test/unit/queue_tests.rb
@@ -29,12 +29,12 @@ module DatWorkerPool::Queue
     end
     subject{ @queue_class }
 
-    should "raise a not implemented error for `push` and `pop` by default" do
+    should "raise a not implemented error for `dwp_push` and `dwp_pop` by default" do
       queue_class = Class.new{ include DatWorkerPool::Queue }
-      queue = queue_class.new.tap(&:start)
+      queue = queue_class.new.tap(&:dwp_start)
 
-      assert_raises(NotImplementedError){ queue.push(Factory.string) }
-      assert_raises(NotImplementedError){ queue.pop }
+      assert_raises(NotImplementedError){ queue.dwp_push(Factory.string) }
+      assert_raises(NotImplementedError){ queue.dwp_pop }
     end
 
   end
@@ -46,80 +46,80 @@ module DatWorkerPool::Queue
     end
     subject{ @queue }
 
-    should have_imeths :start, :signal_shutdown, :shutdown
+    should have_imeths :dwp_start, :dwp_signal_shutdown, :dwp_shutdown
     should have_imeths :running?, :shutdown?
-    should have_imeths :push, :pop
+    should have_imeths :dwp_push, :dwp_pop
 
-    should "set its flags using `start` and `shutdown`" do
+    should "set its flags using `dwp_start` and `dwp_shutdown`" do
       assert_false subject.running?
       assert_true  subject.shutdown?
-      subject.start
+      subject.dwp_start
       assert_true  subject.running?
       assert_false subject.shutdown?
-      subject.shutdown
+      subject.dwp_shutdown
       assert_false subject.running?
       assert_true  subject.shutdown?
     end
 
-    should "call `start!` using `start`" do
+    should "call `start!` using `dwp_start`" do
       assert_false subject.start_called
-      subject.start
+      subject.dwp_start
       assert_true subject.start_called
     end
 
-    should "set its shutdown flag using `signal_shutdown`" do
+    should "set its shutdown flag using `dwp_signal_shutdown`" do
       assert_false subject.running?
       assert_false subject.shutdown_called
-      subject.start
+      subject.dwp_start
       assert_true  subject.running?
       assert_false subject.shutdown_called
-      subject.signal_shutdown
+      subject.dwp_signal_shutdown
       assert_false subject.running?
       assert_false subject.shutdown_called
     end
 
-    should "call `shutdown!` using `shutdown`" do
+    should "call `shutdown!` using `dwp_shutdown`" do
       assert_false subject.shutdown_called
-      subject.shutdown
+      subject.dwp_shutdown
       assert_true subject.shutdown_called
     end
 
-    should "raise an error if `push` is called when the queue isn't running" do
+    should "raise an error if `dwp_push` is called when the queue isn't running" do
       assert_false subject.running?
-      assert_raise(RuntimeError){ subject.push(Factory.string) }
-      subject.start
-      assert_nothing_raised{ subject.push(Factory.string) }
-      subject.shutdown
-      assert_raise(RuntimeError){ subject.push(Factory.string) }
+      assert_raise(RuntimeError){ subject.dwp_push(Factory.string) }
+      subject.dwp_start
+      assert_nothing_raised{ subject.dwp_push(Factory.string) }
+      subject.dwp_shutdown
+      assert_raise(RuntimeError){ subject.dwp_push(Factory.string) }
     end
 
-    should "call `push!` using `push`" do
-      subject.start
+    should "call `push!` using `dwp_push`" do
+      subject.dwp_start
 
       work_item = Factory.string
-      subject.push(work_item)
+      subject.dwp_push(work_item)
       assert_equal [work_item], subject.push_called_with
 
       args = Factory.integer(3).times.map{ Factory.string }
-      subject.push(*args)
+      subject.dwp_push(*args)
       assert_equal args, subject.push_called_with
     end
 
-    should "return nothing if `pop` is called when the queue isn't running" do
+    should "return nothing if `dwp_pop` is called when the queue isn't running" do
       subject.pop_result = Factory.string
       assert_false subject.running?
-      assert_nil subject.pop
-      subject.start
-      assert_not_nil subject.pop
-      subject.shutdown
-      assert_nil subject.pop
+      assert_nil subject.dwp_pop
+      subject.dwp_start
+      assert_not_nil subject.dwp_pop
+      subject.dwp_shutdown
+      assert_nil subject.dwp_pop
     end
 
-    should "call `pop!` using `pop`" do
-      subject.start
+    should "call `pop!` using `dwp_pop`" do
+      subject.dwp_start
       subject.pop_result = Factory.string
 
-      value = subject.pop
+      value = subject.dwp_pop
       assert_equal subject.pop_result, value
     end
 

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -231,7 +231,7 @@ class DatWorkerPool::Runner
 
     should "force its workers to shutdown if a non-timeout error occurs" do
       queue_exception = Factory.exception
-      Assert.stub(@queue, :shutdown){ raise queue_exception }
+      Assert.stub(@queue, :dwp_shutdown){ raise queue_exception }
 
       caught_exception = nil
       begin


### PR DESCRIPTION
This namespaces the internal `Queue` methods and ivars. This is to
avoid user-defined methods and ivars accidentally overwriting queue
behavior. This is also consistent with the worker, where
user-defined methods and ivars were also namespaced for the same
reasons.

@kellyredding - Ready for review.