### PR TITLE
Add `LockedObject`, `LockedArray` and `LockedSet` utility classes

### DIFF
--- a/lib/dat-worker-pool/locked_object.rb
+++ b/lib/dat-worker-pool/locked_object.rb
@@ -1,0 +1,57 @@
+require 'thread'
+
+class DatWorkerPool
+
+  class LockedObject
+    attr_reader :mutex
+
+    def initialize(object = nil)
+      @object = object
+      @mutex  = Mutex.new
+    end
+
+    def value
+      @mutex.synchronize{ @object }
+    end
+
+    def set(new_object)
+      @mutex.synchronize{ @object = new_object }
+    end
+
+    def with_lock(&block)
+      @mutex.synchronize{ block.call(@mutex, @object) }
+    end
+
+  end
+
+  class LockedArray < LockedObject
+    def initialize(array = nil)
+      super(array || [])
+    end
+
+    alias :values :value
+
+    def first;  @mutex.synchronize{ @object.first };  end
+    def last;   @mutex.synchronize{ @object.last };   end
+    def empty?; @mutex.synchronize{ @object.empty? }; end
+
+    def push(new_item); @mutex.synchronize{ @object.push(new_item) }; end
+    def pop;            @mutex.synchronize{ @object.pop };            end
+
+    def shift;             @mutex.synchronize{ @object.shift };             end
+    def unshift(new_item); @mutex.synchronize{ @object.unshift(new_item) }; end
+
+    def delete(item); @mutex.synchronize{ @object.delete(item) }; end
+  end
+
+  class LockedSet < LockedObject
+    def initialize; super(Set.new); end
+
+    alias :values :value
+
+    def size;         @mutex.synchronize{ @object.size };         end
+    def add(item);    @mutex.synchronize{ @object.add(item) };    end
+    def remove(item); @mutex.synchronize{ @object.delete(item) }; end
+  end
+
+end

--- a/test/system/use_worker_pool_tests.rb
+++ b/test/system/use_worker_pool_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'dat-worker-pool'
 
+require 'dat-worker-pool/locked_object'
 require 'dat-worker-pool/worker'
 
 class DatWorkerPool
@@ -236,21 +237,6 @@ class DatWorkerPool
       end
     end
 
-  end
-
-  class LockedArray
-    def initialize
-      @mutex = Mutex.new
-      @array = []
-    end
-
-    def push(value)
-      @mutex.synchronize{ @array.push(value) }
-    end
-
-    def values
-      @mutex.synchronize{ @array }
-    end
   end
 
 end

--- a/test/unit/locked_object_tests.rb
+++ b/test/unit/locked_object_tests.rb
@@ -1,0 +1,212 @@
+require 'assert'
+require 'dat-worker-pool/locked_object'
+
+require 'test/support/thread_spies'
+
+class DatWorkerPool::LockedObject
+
+  class UnitTests < Assert::Context
+    setup do
+      @mutex_spy = MutexSpy.new
+      Assert.stub(Mutex, :new){ @mutex_spy }
+    end
+
+  end
+
+  class LockedObjectTests < UnitTests
+    desc "DatWorkerPool::LockedObject"
+    setup do
+      @passed_value = Factory.string
+      @locked_object = DatWorkerPool::LockedObject.new(@passed_value)
+    end
+    subject{ @locked_object }
+
+    should have_readers :mutex
+    should have_imeths :value, :set
+    should have_imeths :with_lock
+
+    should "know its value" do
+      assert_equal @passed_value, subject.value
+    end
+
+    should "default its value to `nil`" do
+      assert_nil DatWorkerPool::LockedObject.new.value
+    end
+
+    should "lock access to its value" do
+      assert_false @mutex_spy.synchronize_called
+      subject.value
+      assert_true @mutex_spy.synchronize_called
+    end
+
+    should "allow setting its value" do
+      new_value = Factory.string
+      subject.set(new_value)
+      assert_equal new_value, subject.value
+    end
+
+    should "lock access to its value when setting it" do
+      assert_false @mutex_spy.synchronize_called
+      subject.set(Factory.string)
+      assert_true @mutex_spy.synchronize_called
+    end
+
+    should "allow accessing its mutex and value with the lock using `with_lock`" do
+      yielded_mutex, yielded_value = [nil, nil]
+      assert_false @mutex_spy.synchronize_called
+      subject.with_lock{ |m, v| yielded_mutex, yielded_value = [m, v] }
+      assert_true @mutex_spy.synchronize_called
+
+      assert_equal subject.mutex, yielded_mutex
+      assert_equal subject.value, yielded_value
+    end
+
+  end
+
+  class LockedArrayTests < UnitTests
+    desc "DatWorkerPool::LockedArray"
+    setup do
+      @locked_array = DatWorkerPool::LockedArray.new
+    end
+    subject{ @locked_array }
+
+    should have_imeths :values
+    should have_imeths :empty?
+    should have_imeths :push, :pop
+    should have_imeths :shift, :unshift
+    should have_imeths :delete
+
+    should "be a dat-worker-pool locked object" do
+      assert DatWorkerPool::LockedArray < DatWorkerPool::LockedObject
+    end
+
+    should "use an empty array for its value" do
+      assert_equal [], subject.value
+    end
+
+    should "alias its value method as values" do
+      assert_same subject.value, subject.values
+    end
+
+    should "know if its empty or not" do
+      assert_true subject.empty?
+      subject.value.push(Factory.string)
+      assert_false subject.empty?
+    end
+
+    should "lock access to checking if its empty" do
+      assert_false @mutex_spy.synchronize_called
+      subject.empty?
+      assert_true @mutex_spy.synchronize_called
+    end
+
+    should "allow pushing and popping to its array" do
+      new_item = Factory.string
+      subject.push(new_item)
+      assert_same new_item, subject.value.last
+
+      result = subject.pop
+      assert_same new_item, result
+    end
+
+    should "lock accessing when pushing/popping" do
+      assert_false @mutex_spy.synchronize_called
+      subject.push(Factory.string)
+      assert_true @mutex_spy.synchronize_called
+
+      @mutex_spy.synchronize_called = false
+      subject.pop
+      assert_true @mutex_spy.synchronize_called
+    end
+
+    should "allow shifting and unshifting to its array" do
+      new_item = Factory.string
+      subject.unshift(new_item)
+      assert_same new_item, subject.value.first
+
+      result = subject.shift
+      assert_same new_item, result
+    end
+
+    should "lock accessing when shifting/unshifting" do
+      assert_false @mutex_spy.synchronize_called
+      subject.unshift(Factory.string)
+      assert_true @mutex_spy.synchronize_called
+
+      @mutex_spy.synchronize_called = false
+      subject.shift
+      assert_true @mutex_spy.synchronize_called
+    end
+
+    should "allow deleting items from its array" do
+      item = Factory.string
+      (Factory.integer(3) + 1).times{ subject.push(item) }
+
+      subject.delete(item)
+      assert_true subject.empty?
+    end
+
+    should "lock access to when deleting" do
+      assert_false @mutex_spy.synchronize_called
+      subject.delete(Factory.string)
+      assert_true @mutex_spy.synchronize_called
+    end
+
+  end
+
+  class LockedSetTests < UnitTests
+    desc "DatWorkerPool::LockedSet"
+    setup do
+      @locked_set = DatWorkerPool::LockedSet.new
+    end
+    subject{ @locked_set }
+
+    should have_imeths :values, :size, :add, :remove
+
+    should "be a dat-worker-pool locked object" do
+      assert DatWorkerPool::LockedSet < DatWorkerPool::LockedObject
+    end
+
+    should "use an empty set for its value" do
+      assert_instance_of Set, subject.value
+      assert_true subject.value.empty?
+    end
+
+    should "alias its value method as values" do
+      assert_same subject.value, subject.values
+    end
+
+    should "know size" do
+      assert_equal 0, subject.size
+      subject.value.add(Factory.string)
+      assert_equal 1, subject.size
+    end
+
+    should "lock access to reading its size" do
+      assert_false @mutex_spy.synchronize_called
+      subject.size
+      assert_true @mutex_spy.synchronize_called
+    end
+
+    should "allow adding and removing on its set" do
+      new_item = Factory.string
+      subject.add(new_item)
+      assert_includes new_item, subject.value
+
+      subject.remove(new_item)
+      assert_not_includes new_item, subject.value
+    end
+
+    should "lock accessing when pushing/popping" do
+      assert_false @mutex_spy.synchronize_called
+      subject.add(Factory.string)
+      assert_true @mutex_spy.synchronize_called
+
+      @mutex_spy.synchronize_called = false
+      subject.remove(Factory.string)
+      assert_true @mutex_spy.synchronize_called
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds `LockedObject`, `LockedArray` and `LockedSet` utility
classes which commonizes an object and mutex being used together.
The mutex is used to lock interactions which the object so it makes
sure only one thread is operating on it at a time. This was already
being done through most of dat-worker-pool, this just formalizes it
and also provides it as a helper for other gems that use
dat-worker-pool.

This adds a base `LockedObject` class which takes a value and
builds a mutex for it. The mutex is used to lock access to the
value. The base `LockedObject` only provides a method for reading
the value, a method for setting it and a helper for accessing the
value with the lock. This is used as the base for the `LockedArray`
and `LockedSet` class.

The `LockedArray` class takes an array and demeters it while using
the mutex to lock access. This is used by the runner for its
workers and the default queue for its work items. By using this in
the runner it fixes a rare bug that could happen when joining
workers while shutting down. Because accessing the workers array
wasn't locked with a mutex, a worker could remove itself while we
were asking for the first worker. If it was the last worker, this
caused `nil` errors. The work items was already locked by a mutex
that the default queue uses to signal workers but this ensures that
when adding additional logic it will lock access as well.
@kellyredding - Ready for review.