### PR TITLE
Rework system tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake'
-gem 'pry'
+gem 'pry', "~> 0.9.0"

--- a/dat-worker-pool.gemspec
+++ b/dat-worker-pool.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("SystemTimer", ["~> 1.2"])
 
-  gem.add_development_dependency("assert", ["~> 2.14"])
+  gem.add_development_dependency("assert", ["~> 2.15"])
 
 end

--- a/lib/dat-worker-pool/locked_object.rb
+++ b/lib/dat-worker-pool/locked_object.rb
@@ -33,6 +33,7 @@ class DatWorkerPool
 
     def first;  @mutex.synchronize{ @object.first };  end
     def last;   @mutex.synchronize{ @object.last };   end
+    def size;   @mutex.synchronize{ @object.size };   end
     def empty?; @mutex.synchronize{ @object.empty? }; end
 
     def push(new_item); @mutex.synchronize{ @object.push(new_item) }; end

--- a/test/system/dat-worker-pool_tests.rb
+++ b/test/system/dat-worker-pool_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'dat-worker-pool'
 
+require 'timeout'
 require 'dat-worker-pool/locked_object'
 require 'dat-worker-pool/worker'
 
@@ -8,85 +9,142 @@ class DatWorkerPool
 
   class SystemTests < Assert::Context
     desc "DatWorkerPool"
+    setup do
+      # at least 2 workers, up to 4
+      @num_workers   = Factory.integer(3) + 1
+      @mutex         = Mutex.new
+      @cond_var      = ConditionVariable.new
+      @worker_params = {
+        :mutex    => @mutex,
+        :cond_var => @cond_var
+      }
+    end
     subject{ @worker_pool }
 
+    # this could loop forever so ensure it doesn't by using a timeout; use
+    # timeout instead of system timer because system timer is paranoid about a
+    # deadlock even though its intended to prevent the deadlock because it times
+    # out the block
+    def wait_for_workers(&block)
+      Timeout.timeout(1) do
+        @mutex.synchronize{ @cond_var.wait(@mutex) } while !block.call
+      end
+    end
+
+    def wait_for_workers_to_become_available
+      wait_for_workers{ @worker_pool.available_worker_count == @num_workers }
+    end
+
+    def wait_for_workers_to_become_unavailable
+      wait_for_workers{ @worker_pool.available_worker_count == 0 }
+    end
+
+    def wait_for_a_worker_to_become_available
+      wait_for_workers{ @worker_pool.available_worker_count != 0 }
+    end
+
+    def wait_for_a_worker_to_become_unavailable
+      wait_for_workers{ @worker_pool.available_worker_count != @num_workers }
+    end
+
   end
 
-  class UseWorkerPoolTests < SystemTests
+  class StartAddProcessAndShutdownTests < SystemTests
     setup do
       @worker_class = Class.new do
-        include DatWorkerPool::Worker
-        def work!(number); params[:results].push(number * 100); end
+        include SystemTestWorker
+        def work!(number)
+          params[:results].push(number * 100)
+          signal_test_suite_thread
+        end
       end
-      @results = LockedArray.new
+
+      # at least 5 work items, up to 10
+      @work_items = (Factory.integer(5) + 5).times.map{ Factory.integer(10) }
+      @results    = LockedArray.new
 
       @worker_pool = DatWorkerPool.new(@worker_class, {
-        :num_workers   => 2,
+        :num_workers   => @num_workers,
         :logger        => TEST_LOGGER,
-        :worker_params => { :results => @results }
+        :worker_params => @worker_params.merge(:results => @results)
       })
-      @worker_pool.start
     end
 
-    should "be able to add work, have it processed and stop the pool" do
-      subject.add_work 1
-      subject.add_work 5
-      subject.add_work 2
-      subject.add_work 4
-      subject.add_work 3
+    should "be able to start, add work, process it and shutdown" do
+      subject.start
+      @work_items.each{ |work_item| subject.add_work(work_item) }
 
-      sleep 0.1 # allow the worker threads to run
-      subject.shutdown(1)
+      wait_for_workers{ @results.size == @work_items.size }
+      subject.shutdown(0)
 
-      assert_includes 100, @results.values
-      assert_includes 200, @results.values
-      assert_includes 300, @results.values
-      assert_includes 400, @results.values
-      assert_includes 500, @results.values
+      exp = @work_items.map{ |number| number * 100 }
+      assert_equal exp, @results.values
     end
 
   end
 
-  class WorkerBehaviorTests < SystemTests
-    desc "workers"
+  class WorkerAvailabilityTests < SystemTests
     setup do
       @worker_class = Class.new do
-        include DatWorkerPool::Worker
-        def work!(seconds); sleep(seconds); end
+        include SystemTestWorker
+        on_available{   signal_test_suite_thread }
+        on_unavailable{ signal_test_suite_thread }
+
+        # this allows controlling how many workers are available and unavailable
+        # the worker will be unavailable until we signal it
+        def work!(work_item)
+          mutex, cond_var = work_item
+          mutex.synchronize{ cond_var.wait(mutex) }
+        end
       end
+      @work_mutex    = Mutex.new
+      @work_cond_var = ConditionVariable.new
+      @work_item     = [@work_mutex, @work_cond_var]
+
       @worker_pool = DatWorkerPool.new(@worker_class, {
-        :num_workers  => 2,
-        :logger       => TEST_LOGGER
+        :num_workers   => @num_workers,
+        :logger        => TEST_LOGGER,
+        :worker_params => @worker_params
       })
       @worker_pool.start
     end
+    teardown do
+      # ensure we wakeup any workers still stuck in their `work!`
+      @work_mutex.synchronize{ @work_cond_var.broadcast }
+      @worker_pool.shutdown(0)
+    end
 
-    should "spawn and wait until work is available" do
-      # the workers should be spawned and available
-      assert_equal 2, subject.available_worker_count
+    should "know if and how many workers are available" do
+      wait_for_workers_to_become_available
+      assert_equal @num_workers, subject.available_worker_count
       assert_true subject.worker_available?
 
-      # only one worker should be available
-      subject.add_work 5
+      # make one worker unavailable
+      subject.add_work(@work_item)
+
+      wait_for_a_worker_to_become_unavailable
+      assert_equal @num_workers - 1, subject.available_worker_count
+      assert_true subject.worker_available?
+
+      # make the rest of the workers unavailable
+      (@num_workers - 1).times{ subject.add_work(@work_item) }
+
+      wait_for_workers_to_become_unavailable
+      assert_equal 0, subject.available_worker_count
+      assert_false subject.worker_available?
+
+      # make one worker available
+      @work_mutex.synchronize{ @work_cond_var.signal }
+
+      wait_for_a_worker_to_become_available
       assert_equal 1, subject.available_worker_count
       assert_true subject.worker_available?
 
-      # neither worker should be available now
-      subject.add_work 5
-      assert_equal 0, subject.available_worker_count
-      assert_false subject.worker_available?
-    end
+      # make the rest of the workers available
+      @work_mutex.synchronize{ @work_cond_var.broadcast }
 
-    should "go back to waiting when they finish working" do
-      assert_equal 2, subject.available_worker_count
-      assert_true subject.worker_available?
-      subject.add_work 1
-      subject.add_work 1
-      assert_equal 0, subject.available_worker_count
-      assert_false subject.worker_available?
-
-      sleep 1 # allow the workers to run
-      assert_equal 2, subject.available_worker_count
+      wait_for_workers_to_become_available
+      assert_equal @num_workers, subject.available_worker_count
       assert_true subject.worker_available?
     end
 
@@ -94,149 +152,246 @@ class DatWorkerPool
 
   class WorkerCallbackTests < SystemTests
     setup do
-      @callbacks_called = {}
-
       @worker_class = Class.new do
-        include DatWorkerPool::Worker
+        include SystemTestWorker
 
-        on_start{ params[:callbacks_called][:on_start] = true }
+        on_start{    params[:callbacks_called][:on_start]    = true }
         on_shutdown{ params[:callbacks_called][:on_shutdown] = true }
 
-        on_available{ params[:callbacks_called][:on_available] = true }
+        on_available{   params[:callbacks_called][:on_available]   = true }
         on_unavailable{ params[:callbacks_called][:on_unavailable] = true }
 
         on_error{ |e, wi| params[:callbacks_called][:on_error] = true }
 
         before_work{ |wi| params[:callbacks_called][:before_work] = true }
-        after_work{ |wi| params[:callbacks_called][:after_work] = true }
+        after_work{ |wi|  params[:callbacks_called][:after_work]  = true }
 
-        def work!(work_item); raise work_item if work_item == 'error'; end
+        on_available{   signal_test_suite_thread }
+        on_unavailable{ signal_test_suite_thread }
+
+        def work!(work_item)
+          params[:finished].push(work_item)
+          signal_test_suite_thread
+          raise if work_item == 'error'
+        end
       end
+      # use one worker to simplify; we only need to see that one worker runs its
+      # callbacks
+      @num_workers      = 1
+      @callbacks_called = {}
+      @finished         = LockedArray.new
 
       @worker_pool = DatWorkerPool.new(@worker_class, {
+        :num_workers   => @num_workers,
         :logger        => TEST_LOGGER,
-        :worker_params => { :callbacks_called => @callbacks_called }
+        :worker_params => @worker_params.merge({
+          :callbacks_called => @callbacks_called,
+          :finished         => @finished
+        })
       })
     end
-    subject{ @worker_pool }
+    teardown do
+      @worker_pool.shutdown(0)
+    end
 
-    should "call the worker callbacks as workers wait or wakeup" do
+    should "run worker callbacks when started" do
       assert_nil @callbacks_called[:on_start]
       assert_nil @callbacks_called[:on_available]
+
       subject.start
+      wait_for_workers_to_become_available
+
       assert_true @callbacks_called[:on_start]
+      assert_true @callbacks_called[:on_available]
+    end
+
+    should "run worker callbacks when work is pushed" do
+      subject.start
+      wait_for_workers_to_become_available
+      @callbacks_called.delete(:on_available)
 
       assert_nil @callbacks_called[:on_unavailable]
       assert_nil @callbacks_called[:before_work]
       assert_nil @callbacks_called[:after_work]
-      subject.add_work Factory.string
+
+      subject.add_work(Factory.string)
+      wait_for_workers do
+        @finished.size == @num_workers &&
+        subject.available_worker_count == @num_workers
+      end
+
       assert_true @callbacks_called[:on_unavailable]
       assert_true @callbacks_called[:before_work]
       assert_true @callbacks_called[:after_work]
       assert_true @callbacks_called[:on_available]
+    end
 
-      @callbacks_called.delete(:on_unavailable)
-      @callbacks_called.delete(:before_work)
-      @callbacks_called.delete(:after_work)
+    should "run worker callbacks when it errors" do
+      subject.start
+      wait_for_workers_to_become_available
       @callbacks_called.delete(:on_available)
+
       assert_nil @callbacks_called[:on_unavailable]
       assert_nil @callbacks_called[:before_work]
       assert_nil @callbacks_called[:on_error]
       assert_nil @callbacks_called[:after_work]
-      assert_nil @callbacks_called[:on_available]
-      subject.add_work 'error'
+
+      subject.add_work('error')
+      wait_for_workers do
+        @finished.size == @num_workers &&
+        subject.available_worker_count == @num_workers
+      end
+
       assert_true @callbacks_called[:on_unavailable]
       assert_true @callbacks_called[:before_work]
       assert_true @callbacks_called[:on_error]
       assert_nil @callbacks_called[:after_work]
       assert_true @callbacks_called[:on_available]
+    end
 
-      @callbacks_called.delete(:on_unavailable)
+    should "run callbacks when its shutdown" do
+      subject.start
+      wait_for_workers_to_become_available
+
+      assert_nil @callbacks_called[:on_unavailable]
       assert_nil @callbacks_called[:on_shutdown]
-      subject.shutdown
+
+      subject.shutdown(0)
+
+      assert_true @callbacks_called[:on_unavailable]
       assert_true @callbacks_called[:on_shutdown]
     end
 
   end
 
   class ShutdownSystemTests < SystemTests
-    desc "shutdown"
     setup do
       @worker_class = Class.new do
-        include DatWorkerPool::Worker
-        def work!(work_item); sleep 1; params[:finished].push(work_item); end
+        include SystemTestWorker
+        on_available{   signal_test_suite_thread }
+        on_unavailable{ signal_test_suite_thread }
+
+        on_error do |error, wi|
+          params[:errored].push([error, wi])
+        end
+
+        # this allows controlling how long a worker takes to finish processing
+        # the work item
+        def work!(work_item)
+          params[:work_mutex].synchronize do
+            params[:work_cond_var].wait(params[:work_mutex])
+          end
+          params[:finished].push(work_item)
+        end
       end
-      @finished = LockedArray.new
-
-      @worker_pool = DatWorkerPool.new(@worker_class, {
-        :num_workers   => 2,
-        :logger        => TEST_LOGGER,
-        :worker_params => { :finished => @finished }
-      })
-      @worker_pool.start
-      @worker_pool.add_work 'a'
-      @worker_pool.add_work 'b'
-      @worker_pool.add_work 'c'
-    end
-
-    should "allow any work that has been picked up to be processed" do
-      # make sure the workers haven't processed any work
-      assert_equal [], @finished.values
-      subject.shutdown(5)
-
-      # NOTE, the last work shouldn't have been processed, as it wasn't
-      # picked up by a worker
-      assert_includes     'a', @finished.values
-      assert_includes     'b', @finished.values
-      assert_not_includes 'c', @finished.values
-
-      assert_equal 0, subject.available_worker_count
-      assert_includes 'c', subject.queue.work_items
-    end
-
-    should "allow jobs to finish by not providing a shutdown timeout" do
-      assert_equal [], @finished.values
-      subject.shutdown
-      assert_includes 'a', @finished.values
-      assert_includes 'b', @finished.values
-    end
-
-  end
-
-  class ForcedShutdownSystemTests < SystemTests
-    desc "forced shutdown"
-    setup do
-      @worker_class = Class.new do
-        include DatWorkerPool::Worker
-
-        on_error{ |e, wi| params[:finished].push(e) }
-
-        def work!(work_item); sleep 1; end
-      end
-      @num_workers = 2
-      @finished    = LockedArray.new
+      @work_mutex    = Mutex.new
+      @work_cond_var = ConditionVariable.new
+      @finished      = LockedArray.new
+      @errored       = LockedArray.new
 
       @worker_pool = DatWorkerPool.new(@worker_class, {
         :num_workers   => @num_workers,
         :logger        => TEST_LOGGER,
-        :worker_params => { :finished => @finished }
+        :worker_params => @worker_params.merge({
+          :work_mutex    => @work_mutex,
+          :work_cond_var => @work_cond_var,
+          :finished      => @finished,
+          :errored       => @errored
+        })
       })
+
       @worker_pool.start
-      @worker_pool.add_work 'a'
-      @worker_pool.add_work 'b'
-      @worker_pool.add_work 'c'
+      wait_for_workers_to_become_available
+
+      # add 1 more work item than we have workers to handle it
+      @work_items = (@num_workers + 1).times.map{ Factory.string }
+      @work_items.each{ |wi| @worker_pool.add_work(wi) }
+      wait_for_workers_to_become_unavailable
+    end
+    teardown do
+      # ensure we wakeup any workers still stuck in their `work!`
+      @work_mutex.synchronize{ @work_cond_var.broadcast }
+      @worker_pool.shutdown(0)
     end
 
-    should "force workers to shutdown if they take too long to finish" do
-      # make sure the workers haven't processed any work
-      assert_equal [], @finished.values
-      subject.shutdown(0.1)
-      assert_equal @num_workers, @finished.values.size
-      @finished.values.each do |error|
-        assert_instance_of DatWorkerPool::ShutdownError, error
+    should "allow any work that has been picked up to finish processing " \
+           "when shutdown without a timeout" do
+      assert_true @finished.empty?
+      assert_true @errored.empty?
+
+      # start the shutdown in a thread, this will hang it indefinitely because
+      # it has no timeout and the workers will never exit on their own (because
+      # they are waiting to be signaled by the cond var)
+      shutdown_thread = Thread.new{ subject.shutdown }
+      shutdown_thread.join(0.1)
+      assert_equal 'sleep', shutdown_thread.status
+
+      # allow the workers to finish working
+      @work_mutex.synchronize{ @work_cond_var.broadcast }
+      wait_for_workers{ @finished.size == @num_workers }
+
+      # ensure we finished what we started processing; assert the size and
+      # includes because we can't ensure the order that the work items are
+      # finished
+      assert_equal @num_workers, @finished.size
+      @finished.values.each do |work_item|
+        assert_includes work_item, @work_items[0, @num_workers]
       end
+
+      # ensure it didn't pick up anymore work
+      assert_equal [@work_items.last], subject.queue.work_items
+
+      # ensure nothing errored
+      assert_true @errored.empty?
+
+      # ensure the shutdown exits
+      shutdown_thread.join
+      assert_false shutdown_thread.alive?
     end
 
+    should "allow any work that has been picked up to finish processing " \
+           "when forced to shutdown because it timed out" do
+      assert_true @finished.empty?
+      assert_true @errored.empty?
+
+      # start the shutdown in a thread, this will hang until the timeout
+      # finishes; this is required otherwise system timer will think we are
+      # triggering a deadlock (it's not a deadlock because of the timeout)
+      shutdown_thread = Thread.new{ subject.shutdown(0) }
+      shutdown_thread.join(0.1)
+      assert_equal 'sleep', shutdown_thread.status
+
+      # wait for the workers to get forced to exit
+      wait_for_workers{ @errored.size == @num_workers }
+
+      # ensure it didn't finish what it started processing
+      assert_true @finished.empty?
+
+      # ensure it didn't pick up anymore work
+      assert_equal [@work_items.last], subject.queue.work_items
+
+      # ensure all the work it picked up was reported to its on-error callback
+      assert_equal @num_workers, @errored.size
+      @errored.values.each do |(exception, work_item)|
+        assert_instance_of ShutdownError, exception
+        assert_includes work_item, @work_items[0, @num_workers]
+      end
+
+      # ensure the shutdown exits
+      shutdown_thread.join
+      assert_false shutdown_thread.alive?
+    end
+
+  end
+
+  module SystemTestWorker
+    def self.included(klass)
+      klass.class_eval{ include DatWorkerPool::Worker }
+    end
+
+    def signal_test_suite_thread
+      params[:mutex].synchronize{ params[:cond_var].signal }
+    end
   end
 
 end

--- a/test/unit/locked_object_tests.rb
+++ b/test/unit/locked_object_tests.rb
@@ -71,7 +71,8 @@ class DatWorkerPool::LockedObject
     subject{ @locked_array }
 
     should have_imeths :values
-    should have_imeths :empty?
+    should have_imeths :first, :last
+    should have_imeths :size, :empty?
     should have_imeths :push, :pop
     should have_imeths :shift, :unshift
     should have_imeths :delete
@@ -86,6 +87,41 @@ class DatWorkerPool::LockedObject
 
     should "alias its value method as values" do
       assert_same subject.value, subject.values
+    end
+
+    should "know its first and last items" do
+      assert_nil subject.first
+      assert_nil subject.last
+
+      subject.value.push(Factory.string)
+      subject.value.push(Factory.string)
+
+      assert_equal subject.values.first, subject.first
+      assert_equal subject.values.last,  subject.last
+    end
+
+    should "lock access to getting its first item" do
+      assert_false @mutex_spy.synchronize_called
+      subject.first
+      assert_true @mutex_spy.synchronize_called
+    end
+
+    should "lock access to getting its last item" do
+      assert_false @mutex_spy.synchronize_called
+      subject.last
+      assert_true @mutex_spy.synchronize_called
+    end
+
+    should "know its size" do
+      assert_equal 0, subject.size
+      subject.value.push(Factory.string)
+      assert_equal 1, subject.size
+    end
+
+    should "lock access to reading its size" do
+      assert_false @mutex_spy.synchronize_called
+      subject.size
+      assert_true @mutex_spy.synchronize_called
     end
 
     should "know if its empty or not" do


### PR DESCRIPTION
This reworks the system tests to be more maintanable, match our
latest conventions and faster.

The tests no longer rely on sleeping or "polling" to achieve
certain scenarios. Instead they use mutexes and condition variables
to ensure certain scenarios are setup. These allow the workers and
test suite thread to signal one another and ensure the workers are
in a specific state before we make an assertion.

This also switches the tests to use randomized data as much as
possible which ensures we don't have magic values that conveniently
make the tests pass.

Finally, this adds a `size` method to the `LockedArray` which is
used by the new system tests.

@kellyredding - Ready for review. The diff is probably not very useful, its a rewrite. The concepts of the old tests are preserved but all the logic has changed significantly. This also sped up the tests quite a bit: 

before:
```
141 tests, 529 results
(3.531781 seconds, 39.923200 tests/s, 149.782787 results/s)
```
after:
```
147 tests, 560 results
(0.522985 seconds, 281.078807 tests/s, 1063.128006 results/s)
```