### PR TITLE
Update workers to signal their test suite thread in worker tests

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,6 +13,8 @@ ROOT_PATH = Pathname.new(File.expand_path('../..', __FILE__))
 require 'logger'
 TEST_LOGGER = Logger.new(ROOT_PATH.join("log/test.log"))
 
+JOIN_SECONDS = 0.001
+
 require 'test/support/factory'
 
 # TODO: put test helpers here...

--- a/test/system/dat-worker-pool_tests.rb
+++ b/test/system/dat-worker-pool_tests.rb
@@ -77,8 +77,10 @@ class DatWorkerPool
       wait_for_workers{ @results.size == @work_items.size }
       subject.shutdown(0)
 
-      exp = @work_items.map{ |number| number * 100 }
-      assert_equal exp, @results.values
+      assert_equal @work_items.size, @results.size
+      @work_items.each do |number|
+        assert_includes number * 100, @results.values
+      end
     end
 
   end
@@ -323,7 +325,7 @@ class DatWorkerPool
       # it has no timeout and the workers will never exit on their own (because
       # they are waiting to be signaled by the cond var)
       shutdown_thread = Thread.new{ subject.shutdown }
-      shutdown_thread.join(0.1)
+      shutdown_thread.join(JOIN_SECONDS)
       assert_equal 'sleep', shutdown_thread.status
 
       # allow the workers to finish working
@@ -358,7 +360,7 @@ class DatWorkerPool
       # finishes; this is required otherwise system timer will think we are
       # triggering a deadlock (it's not a deadlock because of the timeout)
       shutdown_thread = Thread.new{ subject.shutdown(0) }
-      shutdown_thread.join(0.1)
+      shutdown_thread.join(JOIN_SECONDS)
       assert_equal 'sleep', shutdown_thread.status
 
       # wait for the workers to get forced to exit

--- a/test/unit/default_queue_tests.rb
+++ b/test/unit/default_queue_tests.rb
@@ -148,6 +148,7 @@ class DatWorkerPool::DefaultQueue
       @queue.on_pop{ @on_pop_called = true }
 
       @thread = Thread.new{ Thread.current['popped_value'] = @queue.dwp_pop }
+      @thread.join(JOIN_SECONDS)
     end
     subject{ @thread }
 


### PR DESCRIPTION
This updates the workers used in the worker tests to signal their
test suite thread as they move into different states. This makes
the test less fragile and ensures the worker has reached the state
we expect before try and make any assertions. This mimics changes
that were done to the dat-worker-pool system tests to make them
less fragile.

Specifically, this fixes an issue when logging is added to the
workers. This slows down the workers and causes ruby to switch to
other threads. This means it can switch to the test suite thread
and make assertions before the worker has had a chance to do
anything. This causes tests to fail even though they shouldn't if
the worker thread has a chance to run.

This also includes some cleanups to the tests to try and
commonize as much of their setup as possible. This involved
expanding the thread spy to actually run a thread and moving it
into the thread spies support file.

This also fixes a rare related issue in the default queue tests.
Sometimes the thread used in the tests doesn't get to run so the
tests randomly fail. This ensures that it gets to run by joining
it for a short period.

@kellyredding - Ready for review. This was discovered to be an issue when I tried adding logging to the workers. 

The logging also revealed another issue with the order "events" are running. With how I have the current logic, if work raises an error, it will mark itself as available and run its on-available callbacks before it actually handles the error (the ensure is before the error handling). The logging showed this and though it doesn't hurt anything it seems completely out of order and incorrect to say its available before it runs on-error callbacks.