### PR TITLE
Alias `add_work` as `push`

### DIFF
--- a/lib/dat-worker-pool.rb
+++ b/lib/dat-worker-pool.rb
@@ -50,6 +50,7 @@ class DatWorkerPool
     return if work_item.nil?
     @queue.dwp_push work_item
   end
+  alias :push :add_work
 
   def available_worker_count
     @runner.available_worker_count

--- a/lib/dat-worker-pool/worker_pool_spy.rb
+++ b/lib/dat-worker-pool/worker_pool_spy.rb
@@ -44,6 +44,7 @@ class DatWorkerPool
       return if work_item.nil?
       @work_items << work_item
     end
+    alias :push :add_work
 
     def worker_available?
       !!@worker_available

--- a/test/unit/dat-worker-pool_tests.rb
+++ b/test/unit/dat-worker-pool_tests.rb
@@ -59,7 +59,7 @@ class DatWorkerPool
     subject{ @worker_pool }
 
     should have_readers :logger, :queue
-    should have_imeths :start, :shutdown, :add_work
+    should have_imeths :start, :shutdown, :add_work, :push
     should have_imeths :available_worker_count, :worker_available?
 
     should "know its attributes" do
@@ -131,13 +131,17 @@ class DatWorkerPool
       @worker_pool.start
     end
 
-    should "push work onto its queue using `add_work`" do
+    should "be able to add work onto its queue`" do
       work_item = Factory.string
       subject.add_work(work_item)
-      assert_equal [work_item], @queue.pushed_work_items
+      assert_equal work_item, @queue.pushed_work_items.last
+
+      work_item = Factory.string
+      subject.push(work_item)
+      assert_equal work_item, @queue.pushed_work_items.last
     end
 
-    should "not push `nil` work onto its queue using `add_work`" do
+    should "not add `nil` work onto its queue" do
       subject.add_work(nil)
       assert_equal [], @queue.pushed_work_items
     end

--- a/test/unit/worker_pool_spy_tests.rb
+++ b/test/unit/worker_pool_spy_tests.rb
@@ -81,8 +81,11 @@ class DatWorkerPool::WorkerPoolSpy
     should "allow adding work" do
       work_item = Factory.string
       subject.add_work(work_item)
-      assert_equal 1, subject.work_items.size
-      assert_includes work_item, subject.work_items
+      assert_equal work_item, subject.work_items.last
+
+      work_item = Factory.string
+      subject.push(work_item)
+      assert_equal work_item, subject.work_items.last
     end
 
     should "not allow adding `nil` work" do


### PR DESCRIPTION
This alias' the dat-worker-pool `add_work` as `push`. This matches
the queue `push` method and allows staying with the "push" and
"pop" wording if desired.

@kellyredding - Ready for review.