### PR TITLE
Add `work_items` to pool and queue, make pool spy use queue

### DIFF
--- a/lib/dat-worker-pool.rb
+++ b/lib/dat-worker-pool.rb
@@ -52,6 +52,10 @@ class DatWorkerPool
   end
   alias :push :add_work
 
+  def work_items
+    @queue.work_items
+  end
+
   def available_worker_count
     @runner.available_worker_count
   end

--- a/lib/dat-worker-pool/queue.rb
+++ b/lib/dat-worker-pool/queue.rb
@@ -10,6 +10,12 @@ class DatWorkerPool
 
     module InstanceMethods
 
+      # overwrite this method to add custom logic for reading the current work
+      # items on the queue
+      def work_items
+        raise NotImplementedError
+      end
+
       def dwp_start
         @dwp_running = true
         start!

--- a/lib/dat-worker-pool/worker_pool_spy.rb
+++ b/lib/dat-worker-pool/worker_pool_spy.rb
@@ -1,12 +1,13 @@
+require 'dat-worker-pool/worker'
+
 class DatWorkerPool
 
   class WorkerPoolSpy
 
     attr_reader :logger, :queue
     attr_reader :options, :num_workers, :worker_class, :worker_params
-    attr_reader :work_items
     attr_reader :start_called, :shutdown_called, :shutdown_timeout
-    attr_accessor :worker_available
+    attr_accessor :available_worker_count, :worker_available
 
     def initialize(worker_class, options = nil)
       @worker_class = worker_class
@@ -14,37 +15,47 @@ class DatWorkerPool
         raise ArgumentError, "worker class must include `#{DatWorkerPool::Worker}`"
       end
 
-      @options      = options
-      @num_workers  = @options[:num_workers].to_i
+      @options      = options || {}
+      @num_workers  = (@options[:num_workers] || DEFAULT_NUM_WORKERS).to_i
       if @num_workers && @num_workers < MIN_WORKERS
         raise ArgumentError, "number of workers must be at least #{MIN_WORKERS}"
       end
 
+      @queue = @options[:queue] || begin
+        require 'dat-worker-pool/default_queue'
+        DatWorkerPool::DefaultQueue.new
+      end
+
       @logger        = @options[:logger]
-      @queue         = @options[:queue]
       @worker_params = @options[:worker_params]
 
-      @worker_available = false
-      @work_items       = []
-      @start_called     = false
-      @shutdown_called  = false
-      @shutdown_timeout = nil
+      @available_worker_count = 0
+      @worker_available       = false
+      @start_called           = false
+      @shutdown_called        = false
+      @shutdown_timeout       = nil
     end
 
     def start
       @start_called = true
+      @queue.dwp_start
     end
 
     def shutdown(timeout = nil)
       @shutdown_called  = true
       @shutdown_timeout = timeout
+      @queue.dwp_shutdown
     end
 
     def add_work(work_item)
       return if work_item.nil?
-      @work_items << work_item
+      @queue.dwp_push(work_item)
     end
     alias :push :add_work
+
+    def work_items
+      @queue.work_items
+    end
 
     def worker_available?
       !!@worker_available

--- a/test/unit/dat-worker-pool_tests.rb
+++ b/test/unit/dat-worker-pool_tests.rb
@@ -59,7 +59,8 @@ class DatWorkerPool
     subject{ @worker_pool }
 
     should have_readers :logger, :queue
-    should have_imeths :start, :shutdown, :add_work, :push
+    should have_imeths :start, :shutdown
+    should have_imeths :add_work, :push, :work_items
     should have_imeths :available_worker_count, :worker_available?
 
     should "know its attributes" do
@@ -134,16 +135,21 @@ class DatWorkerPool
     should "be able to add work onto its queue`" do
       work_item = Factory.string
       subject.add_work(work_item)
-      assert_equal work_item, @queue.pushed_work_items.last
+      assert_equal work_item, @queue.work_items.last
 
       work_item = Factory.string
       subject.push(work_item)
-      assert_equal work_item, @queue.pushed_work_items.last
+      assert_equal work_item, @queue.work_items.last
     end
 
     should "not add `nil` work onto its queue" do
       subject.add_work(nil)
-      assert_equal [], @queue.pushed_work_items
+      assert_equal [], @queue.work_items
+    end
+
+    should "know its queue's work items" do
+      Factory.integer(3).times{ @queue.dwp_push(Factory.string) }
+      assert_equal @queue.work_items, subject.work_items
     end
 
   end
@@ -162,16 +168,16 @@ class DatWorkerPool
   class TestQueue
     include DatWorkerPool::Queue
 
-    attr_reader :pushed_work_items
+    attr_reader :work_items
 
     def initialize
-      @pushed_work_items = []
+      @work_items = []
     end
 
     private
 
     def push!(work_item)
-      @pushed_work_items << work_item
+      @work_items << work_item
     end
   end
 

--- a/test/unit/queue_tests.rb
+++ b/test/unit/queue_tests.rb
@@ -46,9 +46,14 @@ module DatWorkerPool::Queue
     end
     subject{ @queue }
 
+    should have_imeths :work_items
     should have_imeths :dwp_start, :dwp_signal_shutdown, :dwp_shutdown
     should have_imeths :running?, :shutdown?
     should have_imeths :dwp_push, :dwp_pop
+
+    should "raise a not implemented error using `work_items`" do
+      assert_raises(NotImplementedError){ subject.work_items }
+    end
 
     should "set its flags using `dwp_start` and `dwp_shutdown`" do
       assert_false subject.running?

--- a/test/unit/worker_pool_spy_tests.rb
+++ b/test/unit/worker_pool_spy_tests.rb
@@ -33,9 +33,11 @@ class DatWorkerPool::WorkerPoolSpy
 
     should have_readers :logger, :queue
     should have_readers :options, :num_workers, :worker_class, :worker_params
-    should have_readers :work_items
     should have_readers :start_called, :shutdown_called, :shutdown_timeout
-    should have_accessors :worker_available
+    should have_accessors :available_worker_count, :worker_available
+    should have_imeths :start, :shutdown
+    should have_imeths :add_work, :push, :work_items
+    should have_imeths :worker_available?
 
     should "know its attributes" do
       assert_equal @worker_class,            subject.worker_class
@@ -44,12 +46,24 @@ class DatWorkerPool::WorkerPoolSpy
       assert_equal @options[:logger],        subject.logger
       assert_equal @options[:queue],         subject.queue
       assert_equal @options[:worker_params], subject.worker_params
+      assert_equal 0,                        subject.available_worker_count
 
       assert_false subject.worker_available?
-      assert_equal [], subject.work_items
       assert_false subject.start_called
       assert_false subject.shutdown_called
       assert_nil subject.shutdown_timeout
+    end
+
+    should "default its attributes" do
+      worker_pool_spy = @spy_class.new(@worker_class)
+      assert_instance_of DatWorkerPool::DefaultQueue, worker_pool_spy.queue
+      assert_equal DatWorkerPool::DEFAULT_NUM_WORKERS, worker_pool_spy.num_workers
+    end
+
+    should "allow setting its available worker count" do
+      integer = Factory.integer
+      subject.available_worker_count = integer
+      assert_equal integer, subject.available_worker_count
     end
 
     should "allow setting whether a worker is available" do
@@ -65,11 +79,31 @@ class DatWorkerPool::WorkerPoolSpy
       assert_true subject.start_called
     end
 
+    should "start its queue when it's been started" do
+      assert_false subject.queue.running?
+      subject.start
+      assert_true subject.queue.running?
+    end
+
     should "know if it's been shutdown" do
       assert_false subject.shutdown_called
       subject.shutdown
       assert_true subject.shutdown_called
       assert_nil subject.shutdown_timeout
+    end
+
+  end
+
+  class StartedTests < InitTests
+    desc "and started"
+    setup do
+      @worker_pool_spy.start
+    end
+
+    should "shutdown its queue when it's been shutdown" do
+      assert_false subject.queue.shutdown?
+      subject.shutdown
+      assert_true subject.queue.shutdown?
     end
 
     should "know if it's been shutdown with a timeout" do
@@ -78,19 +112,24 @@ class DatWorkerPool::WorkerPoolSpy
       assert_equal timeout, subject.shutdown_timeout
     end
 
-    should "allow adding work" do
+    should "allow adding work to its queue" do
       work_item = Factory.string
       subject.add_work(work_item)
-      assert_equal work_item, subject.work_items.last
+      assert_equal work_item, subject.queue.work_items.last
 
       work_item = Factory.string
       subject.push(work_item)
-      assert_equal work_item, subject.work_items.last
+      assert_equal work_item, subject.queue.work_items.last
     end
 
     should "not allow adding `nil` work" do
       subject.add_work(nil)
-      assert_equal 0, subject.work_items.size
+      assert_equal 0, subject.queue.work_items.size
+    end
+
+    should "know its queues work items" do
+      Factory.integer(3).times{ subject.queue.dwp_push(Factory.string) }
+      assert_equal subject.queue.work_items, subject.work_items
     end
 
   end


### PR DESCRIPTION
This updates `DatWorkerPool` and `Queue` to have `work_items`
methods and updates the `WorkerPoolSpy` to use its queue for its
work items. This makes using the default queue with a worker pool
simpler and makes the worker pool spy match the real worker pool
more making it a better spy.

Gems (specifically, dat-tcp) need to read the current work items
on the worker pool's default queue. Without a `work_items` method
on the worker pool they have to manually build a default queue
and pass that into the worker pool. This makes it more annoying to
use a default queue. Ideally, if you want to use the default queue
you never need to pass it into the worker pool.

To allow `DatWorkerPool` to provide a `work_items` method the
`Queue` mixin now provides it by default but it raises a not
implemented error. Like the other methods it provides, it can
be re-defined to provide custom logic. The `DefaultQueue` already
does this allowing access to its in-memory array of work items.

This also changes the worker pool spy to use its queue. Previously,
it took a queue but ignored it and stored its work items on itself.
This doesn't work as expected if a custom queue is passed in, it
wouldn't add work items to the custom queue like a real worker pool
would. To make sure it behaves more like a real worker pool, it
will now start, shutdown, add work and read work items from its
queue just like the real worker pool does.

This also adds some missing spy methods to the worker pool spy.

@kellyredding - Ready for review.