### PR TITLE
Add logging to runner and workers

### DIFF
--- a/lib/dat-worker-pool.rb
+++ b/lib/dat-worker-pool.rb
@@ -10,7 +10,7 @@ class DatWorkerPool
   DEFAULT_NUM_WORKERS = 1
   MIN_WORKERS         = 1
 
-  attr_reader :logger, :queue
+  attr_reader :queue
 
   def initialize(worker_class, options = nil)
     if !worker_class.kind_of?(Class) || !worker_class.include?(DatWorkerPool::Worker)
@@ -23,8 +23,6 @@ class DatWorkerPool
       raise ArgumentError, "number of workers must be at least #{MIN_WORKERS}"
     end
 
-    @logger = options[:logger] || NullLogger.new
-
     @queue = options[:queue] || begin
       require 'dat-worker-pool/default_queue'
       DatWorkerPool::DefaultQueue.new
@@ -32,6 +30,7 @@ class DatWorkerPool
 
     @runner = DatWorkerPool::Runner.new({
       :num_workers   => num_workers,
+      :logger        => options[:logger],
       :queue         => @queue,
       :worker_class  => worker_class,
       :worker_params => options[:worker_params]
@@ -62,12 +61,6 @@ class DatWorkerPool
 
   def worker_available?
     @runner.worker_available?
-  end
-
-  class NullLogger
-    ::Logger::Severity.constants.each do |name|
-      define_method(name.downcase){ |*args| } # no-op
-    end
   end
 
   # this error should never be "swallowed", if it is caught be sure to re-raise

--- a/lib/dat-worker-pool/runner.rb
+++ b/lib/dat-worker-pool/runner.rb
@@ -8,13 +8,19 @@ class DatWorkerPool
   class Runner
 
     attr_reader :num_workers, :worker_class, :worker_params
-    attr_reader :queue
+    attr_reader :logger_proxy, :queue
 
     def initialize(args)
       @num_workers   = args[:num_workers]
       @queue         = args[:queue]
       @worker_class  = args[:worker_class]
       @worker_params = args[:worker_params]
+
+      @logger_proxy = if args[:logger]
+        LoggerProxy.new(args[:logger])
+      else
+        NullLoggerProxy.new
+      end
 
       @workers           = LockedArray.new
       @available_workers = LockedSet.new
@@ -25,8 +31,9 @@ class DatWorkerPool
     end
 
     def start
+      log{ "Starting worker pool with #{@num_workers} worker(s)" }
       @queue.dwp_start
-      @num_workers.times{ build_worker }
+      @num_workers.times.each{ |n| build_worker(n + 1) }
     end
 
     # the workers should be told to shutdown before the queue because the queue
@@ -40,6 +47,10 @@ class DatWorkerPool
     # non-timeout errors will be re-raised so they can be caught and handled (or
     # shown when the process exits)
     def shutdown(timeout = nil, backtrace = nil)
+      log do
+        timeout_message = timeout ? "#{timeout} second(s)" : "none"
+        "Shutting down worker pool (timeout: #{timeout_message})"
+      end
       begin
         @workers.with_lock{ |m, ws| ws.each(&:dwp_signal_shutdown) }
         @queue.dwp_signal_shutdown
@@ -53,6 +64,7 @@ class DatWorkerPool
       rescue TimeoutInterruptError => exception
         force_workers_to_shutdown(exception, timeout, backtrace)
       end
+      log{ "Finished shutting down" }
     end
 
     def available_worker_count
@@ -71,10 +83,18 @@ class DatWorkerPool
       @available_workers.remove(worker.object_id)
     end
 
+    def log(&message_block)
+      @logger_proxy.runner_log(&message_block)
+    end
+
+    def worker_log(worker, &message_block)
+      @logger_proxy.worker_log(worker, &message_block)
+    end
+
     private
 
-    def build_worker
-      @workers.push(@worker_class.new(self, @queue).tap(&:dwp_start))
+    def build_worker(number)
+      @workers.push(@worker_class.new(self, @queue, number).tap(&:dwp_start))
     end
 
     # use an until loop instead of each to join all the workers, while we are
@@ -83,12 +103,16 @@ class DatWorkerPool
     # exceptions that aren't handled by a thread when its joined, this allows
     # all the workers to be joined
     def wait_for_workers_to_shutdown
+      log{ "Waiting for #{@workers.size} workers to shutdown" }
       while !(worker = @workers.first).nil?
         begin
           worker.dwp_join
-        rescue StandardError
+        rescue StandardError => exception
+          log{ "An error occurred while waiting for worker " \
+               "to shutdown ##{worker.dwp_number}" }
         end
         remove_worker(worker)
+        log{ "Worker ##{worker.dwp_number} shutdown" }
       end
     end
 
@@ -100,14 +124,21 @@ class DatWorkerPool
     # workers ensure), then it won't cause the forced shutdown to end
     # prematurely
     def force_workers_to_shutdown(orig_exception, timeout, backtrace)
+      log{ "Forcing #{@workers.size} workers to shutdown" }
       error = build_forced_shutdown_error(orig_exception, timeout, backtrace)
       while !(worker = @workers.first).nil?
         worker.dwp_raise(error)
         begin
           worker.dwp_join
-        rescue StandardError, ShutdownError
+        rescue StandardError => exception
+          log{ "An error occurred while waiting for worker " \
+               "to shutdown ##{worker.dwp_number} (forced)" }
+        rescue ShutdownError
+          # these are expected (because we raised them in the thread) so they
+          # don't need to be logged
         end
         remove_worker(worker)
+        log{ "Worker ##{worker.dwp_number} shutdown (forced)" }
       end
     end
 
@@ -130,6 +161,12 @@ class DatWorkerPool
       end
     end
 
+    # this needs to be an `Interrupt` to be sure we don't accidentally catch it
+    # when rescueing exceptions; in the shutdown methods we rescue any errors
+    # from `worker.join`, this will also rescue the timeout error if its a
+    # standard error and will keep it from doing a forced shutdown
+    TimeoutInterruptError = Class.new(Interrupt)
+
     module OptionalTimeout
       def self.new(seconds, &block)
         if seconds
@@ -140,11 +177,19 @@ class DatWorkerPool
       end
     end
 
-    # this needs to be an `Interrupt` to be sure we don't accidentally catch it
-    # when rescueing exceptions; in the shutdown methods we rescue any errors
-    # from `worker.join`, this will also rescue the timeout error if its a
-    # standard error and will keep it from doing a forced shutdown
-    TimeoutInterruptError = Class.new(Interrupt)
+    class LoggerProxy < Struct.new(:logger)
+      def runner_log(&message_block)
+        self.logger.debug("[DWP] #{message_block.call}")
+      end
+      def worker_log(worker, &message_block)
+        self.logger.debug("[DWP-#{worker.dwp_number}] #{message_block.call}")
+      end
+    end
+
+    class NullLoggerProxy
+      def runner_log(&block); end
+      def worker_log(worker, &block); end
+    end
 
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,7 +11,10 @@ require 'pathname'
 ROOT_PATH = Pathname.new(File.expand_path('../..', __FILE__))
 
 require 'logger'
-TEST_LOGGER = Logger.new(ROOT_PATH.join("log/test.log"))
+TEST_LOGGER = if ENV['DEBUG']
+  # don't show datetime in the logs
+  Logger.new(ROOT_PATH.join("log/test.log")).tap{ |l| l.datetime_format = '' }
+end
 
 JOIN_SECONDS = 0.001
 

--- a/test/unit/dat-worker-pool_tests.rb
+++ b/test/unit/dat-worker-pool_tests.rb
@@ -26,7 +26,7 @@ class DatWorkerPool
     desc "when init"
     setup do
       @num_workers   = Factory.integer(4)
-      @logger        = NullLogger.new
+      @logger        = TEST_LOGGER
       @queue         = TestQueue.new
       @worker_params = { Factory.string => Factory.string }
 
@@ -58,19 +58,19 @@ class DatWorkerPool
     end
     subject{ @worker_pool }
 
-    should have_readers :logger, :queue
+    should have_readers :queue
     should have_imeths :start, :shutdown
     should have_imeths :add_work, :push, :work_items
     should have_imeths :available_worker_count, :worker_available?
 
     should "know its attributes" do
-      assert_equal @logger, subject.logger
       assert_equal @queue,  subject.queue
     end
 
     should "build a runner" do
       exp = {
         :num_workers   => @num_workers,
+        :logger        => @logger,
         :queue         => @queue,
         :worker_class  => @worker_class,
         :worker_params => @worker_params
@@ -80,7 +80,6 @@ class DatWorkerPool
 
     should "default its attributes" do
       worker_pool = @worker_pool_class.new(@worker_class)
-      assert_instance_of NullLogger, worker_pool.logger
       assert_instance_of DatWorkerPool::DefaultQueue, worker_pool.queue
 
       assert_equal DEFAULT_NUM_WORKERS, @runner_spy.args[:num_workers]
@@ -151,17 +150,6 @@ class DatWorkerPool
       Factory.integer(3).times{ @queue.dwp_push(Factory.string) }
       assert_equal @queue.work_items, subject.work_items
     end
-
-  end
-
-  class NullLoggerTests < UnitTests
-    desc "NullLogger"
-    setup do
-      @logger = NullLogger.new
-    end
-    subject{ @logger }
-
-    should have_imeths :debug, :info, :error
 
   end
 

--- a/test/unit/worker_pool_spy_tests.rb
+++ b/test/unit/worker_pool_spy_tests.rb
@@ -22,7 +22,7 @@ class DatWorkerPool::WorkerPoolSpy
       @worker_class = Class.new{ include DatWorkerPool::Worker }
       @options = {
         :num_workers   => Factory.integer,
-        :logger        => DatWorkerPool::NullLogger.new,
+        :logger        => TEST_LOGGER,
         :queue         => DatWorkerPool::DefaultQueue.new,
         :worker_params => { Factory.string => Factory.string }
       }


### PR DESCRIPTION
This updates the runner and workers to have debug logging. This is
to help with seeing what a worker pool and its workers are doing.

The runner will now log when it starts and shuts down. It logs the
number of workers it is starting or waiting to shut down and will
log if it is doing a normal shutdown or forcing the workers to
shutdown.

The worker will log as it moves between its different states:
starting, available, unavailable, working and shutting down. It
also logs any errors that occur.

In addition to adding logging, workers are now given a number by
their runner. This is used in their logs to identify the worker
and is also a helper that can be used in custom logging or other
logic as needed.

@kellyredding - Ready for review.