### PR TITLE
replace SystemTimer with MuchTimeout

### DIFF
--- a/dat-worker-pool.gemspec
+++ b/dat-worker-pool.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.16.1"])
 
-  gem.add_dependency("SystemTimer", ["~> 1.2"])
+  gem.add_dependency("much-timeout", ["~> 0.1.0"])
 
 end

--- a/lib/dat-worker-pool.rb
+++ b/lib/dat-worker-pool.rb
@@ -42,7 +42,7 @@ class DatWorkerPool
   end
 
   def shutdown(timeout = nil)
-    @runner.shutdown(timeout, caller)
+    @runner.shutdown(timeout)
   end
 
   def add_work(work_item)

--- a/test/system/dat-worker-pool_tests.rb
+++ b/test/system/dat-worker-pool_tests.rb
@@ -351,7 +351,7 @@ class DatWorkerPool
       assert_false shutdown_thread.alive?
     end
 
-    should "allow any work that has been picked up to finish processing " \
+    should "not allow any work that has been picked up to finish processing " \
            "when forced to shutdown because it timed out" do
       assert_true @finished.empty?
       assert_true @errored.empty?
@@ -361,7 +361,7 @@ class DatWorkerPool
       # triggering a deadlock (it's not a deadlock because of the timeout)
       shutdown_thread = Thread.new{ subject.shutdown(0) }
       shutdown_thread.join(JOIN_SECONDS)
-      assert_equal 'sleep', shutdown_thread.status
+      assert_false shutdown_thread.status
 
       # wait for the workers to get forced to exit
       wait_for_workers{ @errored.size == @num_workers }

--- a/test/unit/dat-worker-pool_tests.rb
+++ b/test/unit/dat-worker-pool_tests.rb
@@ -1,7 +1,6 @@
 require 'assert'
 require 'dat-worker-pool'
 
-require 'system_timer'
 require 'dat-worker-pool/queue'
 require 'dat-worker-pool/runner'
 require 'dat-worker-pool/worker'
@@ -97,8 +96,6 @@ class DatWorkerPool
       subject.shutdown
       assert_true @runner_spy.shutdown_called
       assert_nil @runner_spy.shutdown_timeout
-      exp = "test/unit/dat-worker-pool_tests.rb"
-      assert_match exp, @runner_spy.shutdown_backtrace.first
 
       timeout = Factory.integer
       subject.shutdown(timeout)
@@ -172,14 +169,13 @@ class DatWorkerPool
   class RunnerSpy < DatWorkerPool::Runner
     attr_accessor :args
     attr_reader :start_called, :shutdown_called
-    attr_reader :shutdown_timeout, :shutdown_backtrace
+    attr_reader :shutdown_timeout
 
     def initialize
       super({})
       @start_called       = false
       @shutdown_called    = false
       @shutdown_timeout   = nil
-      @shutdown_backtrace = nil
     end
 
     def start
@@ -187,11 +183,10 @@ class DatWorkerPool
       @start_called = true
     end
 
-    def shutdown(timeout, backtrace)
+    def shutdown(timeout)
       @args[:queue].dwp_shutdown
-      @shutdown_called    = true
-      @shutdown_timeout   = timeout
-      @shutdown_backtrace = backtrace
+      @shutdown_called  = true
+      @shutdown_timeout = timeout
     end
   end
 

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -1,7 +1,6 @@
 require 'assert'
 require 'dat-worker-pool/worker'
 
-require 'system_timer'
 require 'dat-worker-pool/default_queue'
 require 'dat-worker-pool/runner'
 require 'test/support/thread_spies'


### PR DESCRIPTION
This is part of getting this working in modern ruby versions.
SystemTimer isn't compatible.  This switches to using our new
much-timeout gem for handling timeouts.

There are a couple of minor tweaks related to this change:

* MuchTimeout has a `just_optional_timeout` method that not only
  takes care of optionally applying the timeout but also removes
  any exception being raised when a timeout occurs.
* The previous shutdown logic attempted to abstract the dwp
  internals in the shutdown error backtraces by accepting a custom
  caller to use as the backtrace.  This proved to be less helpful
  b/c you never get to see where in the worker the shutdown error
  occurred.  This removes all the custom backtrace logic.
* this fixes a test now that timeouts of zero immediately interrupt
  (this wasn't the case with SystemTimer)

@jcredding ready for review.