### PR TITLE
Update test suite to work with newer versions of ruby

### DIFF
--- a/test/support/signal_test_worker.rb
+++ b/test/support/signal_test_worker.rb
@@ -1,0 +1,71 @@
+require 'much-timeout'
+require 'dat-worker-pool/worker'
+
+module SignalTestWorker
+  def self.included(klass)
+    klass.class_eval{ include DatWorkerPool::Worker }
+  end
+
+  private
+
+  def signal_test_suite_thread
+    params[:signal_worker_mutex].synchronize do
+      params[:signal_worker_cond_var].signal
+    end
+  end
+
+  module TestHelpers
+
+    def self.included(klass)
+      klass.class_eval do
+        setup do
+          # at least 2 workers, up to 4
+          @num_workers = Factory.integer(3) + 1
+
+          @signal_worker_mutex    = Mutex.new
+          @signal_worker_cond_var = ConditionVariable.new
+
+          @worker_params = {
+            :signal_worker_mutex    => @signal_worker_mutex,
+            :signal_worker_cond_var => @signal_worker_cond_var
+          }
+        end
+      end
+    end
+
+    private
+
+    # this could loop forever so ensure it doesn't by using a timeout
+    def wait_for_workers(&block)
+      MuchTimeout.just_timeout(1, {
+        :do => proc{
+          while !block.call do
+            @signal_worker_mutex.synchronize do
+              @signal_worker_cond_var.wait(@signal_worker_mutex)
+            end
+          end
+        },
+        :on_timeout => proc{
+          raise "timed out waiting for workers" unless block.call
+        }
+      })
+    end
+
+    def wait_for_workers_to_become_available
+      wait_for_workers{ subject.available_worker_count == @num_workers }
+    end
+
+    def wait_for_workers_to_become_unavailable
+      wait_for_workers{ subject.available_worker_count == 0 }
+    end
+
+    def wait_for_a_worker_to_become_available
+      wait_for_workers{ subject.available_worker_count != 0 }
+    end
+
+    def wait_for_a_worker_to_become_unavailable
+      wait_for_workers{ subject.available_worker_count != @num_workers }
+    end
+
+  end
+end

--- a/test/unit/default_queue_tests.rb
+++ b/test/unit/default_queue_tests.rb
@@ -162,6 +162,7 @@ class DatWorkerPool::DefaultQueue
 
       value = Factory.string
       @queue.dwp_push(value)
+      subject.join(JOIN_SECONDS)
 
       assert_not subject.alive?
       assert_equal value, subject['popped_value']
@@ -176,6 +177,7 @@ class DatWorkerPool::DefaultQueue
       # sleeps and grabs the lock and work item before the thread being woken
       # up
       @work_items.with_lock{ @cond_var_spy.signal }
+      subject.join(JOIN_SECONDS)
 
       assert_equal 'sleep', subject.status
       assert_equal 2, @cond_var_spy.wait_call_count
@@ -186,6 +188,7 @@ class DatWorkerPool::DefaultQueue
       assert_equal 1, @cond_var_spy.wait_call_count
 
       @queue.dwp_shutdown
+      subject.join(JOIN_SECONDS)
 
       assert_not subject.alive?
       assert_equal 1, @cond_var_spy.wait_call_count
@@ -207,6 +210,7 @@ class DatWorkerPool::DefaultQueue
       # accesses the array directly and pushes an item on it
       @work_items.push(Factory.string)
       @queue.dwp_shutdown
+      subject.join(JOIN_SECONDS)
 
       assert_not subject.alive?
       assert_nil subject['popped_value']


### PR DESCRIPTION
This updates the test suite to work with newer versions of ruby.
This mostly involved doing more "hand-holding" to ensure threads
were given a chance to run or to reach a certain state before any
assertions were done. This gets all the tests passing in newer
versions of ruby and in ruby 1.8.7.

This fixes the default queue unit tests by simply adding some extra
thread joins to ensure it gets a chance to run. This allows it to
reach the expected state before any assertions happen.

This fixes the runner unit tests by making a few changes:

* The workers now signal when they become available and
  unavailable. This allows the tests to ensure the workers have
  reached an expected state before running any assertions. This
  logic was commonized from the system tests so both sets of tests
  can make use of it.
* The workers no longer override their `dwp_raise` method which
  caused them to not behave as they normally would. Instead, they
  spy what errors occurred by using the `on_error` callback.
* The workers no longer raise a join error via their `dwp_join`
  method. They now use the `on_shutdown` callback to raise join
  errors which follows the normal behavior of a thread raising
  any unhandled errors when its joined.
* The workers now suspend their state to test how they can be
  forced to shutdown by running special "hang" work items.
  Previously this was done during shutdown and via the overriden
  methods. Now that the methods aren't overriden the old logic
  didn't work.

All of these changes fixed the runner tests in newer versions of
ruby. Overall, these changes let the workers behave normally which
avoids issues between the different versions of ruby.

This also cleans up a few spots that were doing special behavior
because they expected system timer and its aggressive deadlock
catching. This is no longer needed now that we are using
`MuchTimeout`. These were locations that system timer thought
were deadlocks but weren't because we were running them in a
timeout.

Finally, this includes some minor cleanups to switch to using
`MuchTimeout` instead of `Timeout`. This is more consistent and
ensures we don't have issues if `Timeout`'s implementation changes
between ruby versions. As part of this, the worker unit tests were
updated to only stub `Thread.new` the first time it was called
because `MuchTimeout` would call `Thread.new` and use the stub
which caused errors. This makes the stub better and only stub its
`Thread.new` call and not other unintended calls.

@kellyredding - Ready for review.