### PR TITLE
Rescue `LoadError` and `NotImplementedError` in `Worker`

### DIFF
--- a/lib/dat-worker-pool/worker.rb
+++ b/lib/dat-worker-pool/worker.rb
@@ -8,10 +8,15 @@ class DatWorkerPool
 
     # these are standard error classes that we rescue, handle and don't reraise
     # in the work loop, this keeps the worker thread from shutting down
-    # unexpectedly; `Timeout::Error` is a common non `StandardError` exception
-    # that should be treated like a `StandardError`, we don't want an uncaught
-    # `Timeout::Error` to shutdown a worker thread
-    STANDARD_ERROR_CLASSES = [StandardError, Timeout::Error].freeze
+    # unexpectedly; `LoadError`, `NotImplementedError` and `Timeout::Error` are
+    # common non `StandardError` exception that should be treated like a
+    # `StandardError`, we don't want one of these to shutdown a worker thread
+    STANDARD_ERROR_CLASSES = [
+      StandardError,
+      LoadError,
+      NotImplementedError,
+      Timeout::Error
+    ].freeze
 
     def self.included(klass)
       klass.class_eval do

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -31,7 +31,7 @@ module DatWorkerPool::Worker
     should have_imeths :prepend_before_work, :prepend_after_work
 
     should "know its standard error classes" do
-      exp = [StandardError, Timeout::Error]
+      exp = [StandardError, LoadError, NotImplementedError, Timeout::Error]
       assert_equal exp, DatWorkerPool::Worker::STANDARD_ERROR_CLASSES
     end
 


### PR DESCRIPTION
This updates the `Worker` to rescue `LoadError` and
`NotImplementedError` exceptions. These are non `StandardError`
exceptions that would cause the worker thread to exit if they
aren't rescued. It's relatively likely these can occur in code
being run by a worker. It's a better workflow for these to be
rescued and passed to any configured error procs rather than a
worker shutting down. This allows the error procs to notify that
there was a problem. Otherwise the worker thread exits and there
isn't any chance for a notification.

@kellyredding - Ready for review.
